### PR TITLE
minimal stm32l0x2 support. Alternate Function setup for SPI pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ license = "0BSD"
 name = "stm32l0xx-hal"
 readme = "README.md"
 repository = "https://github.com/stm32-rs/stm32l0xx-hal"
-version = "0.1.0"
+version = "0.1.1"
 
 [package.metadata.docs.rs]
-features = ["stm32l0x1", "rt"]
+features = ["stm32l0x1", "stm32l0x2", "rt"]
 
 [dependencies]
 embedded-hal = { version = "0.2.2", features = ["unproven"] }
@@ -38,7 +38,6 @@ nb = "0.1.2"
 
 [dependencies.stm32l0]
 version = "0.7.0"
-features = ["stm32l0x1", "rt"]
 
 [dev-dependencies]
 panic-halt = "0.2.0"
@@ -47,6 +46,7 @@ panic-semihosting = "0.5.1"
 [features]
 rt = ["stm32l0/rt"]
 stm32l0x1 = ["stm32l0/stm32l0x1"]
+stm32l0x2 = ["stm32l0/stm32l0x2"]
 
 [profile.dev]
 codegen-units = 1
@@ -67,3 +67,11 @@ required-features = ["rt"]
 [[example]]
 name = "timer_interrupt_rtfm"
 required-features = ["rt"]
+
+[[example]]
+name = "adc_pwm"
+required-features = ["stm32l0x1"]
+
+[[example]]
+name = "pwm"
+required-features = ["stm32l0x1"]

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #![deny(unsafe_code)]
 #![no_main]
 #![no_std]

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #![deny(unsafe_code)]
 #![no_main]
 #![no_std]

--- a/examples/button_irq.rs
+++ b/examples/button_irq.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
@@ -14,7 +12,7 @@ use cortex_m_rt::entry;
 use stm32l0xx_hal::{
     exti::TriggerEdge,
     gpio::*,
-    pac::{self, interrupt, Interrupt, EXTI},
+    pac::{self, Interrupt, EXTI},
     prelude::*,
     rcc::Config,
 };
@@ -57,7 +55,6 @@ fn main() -> ! {
     }
 }
 
-#[interrupt]
 fn EXTI0_1() {
     // Keep the LED state.
     static mut STATE: bool = false;
@@ -69,13 +66,16 @@ fn EXTI0_1() {
 
             // Change the LED state on each interrupt.
             if let Some(ref mut led) = LED.borrow(cs).borrow_mut().deref_mut() {
-                if *STATE {
-                    led.set_low();
-                    *STATE = false;
-                } else {
-                    led.set_high();
-                    *STATE = true;
+                unsafe {
+                    if STATE {
+                        led.set_low();
+                        STATE = false;
+                    } else {
+                        led.set_high();
+                        STATE = true;
+                    }
                 }
+                
             }
         }
     });

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -26,8 +26,16 @@ fn main() -> ! {
     let rx_pin = gpioa.pa10;
 
     // Configure the serial peripheral.
+    #[cfg(feature = "stm32l0x1")]
     let serial = dp
         .USART2
+        .usart((tx_pin, rx_pin), serial::Config::default(), &mut rcc)
+        .unwrap();
+
+    // Configure the serial peripheral.
+    #[cfg(feature = "stm32l0x2")]
+    let serial = dp
+        .USART1
         .usart((tx_pin, rx_pin), serial::Config::default(), &mut rcc)
         .unwrap();
 
@@ -35,7 +43,7 @@ fn main() -> ! {
 
     // core::fmt::Write is implemented for tx.
     //writeln!(tx, "Hello, world!").unwrap();
-    
+
     loop {
         // Echo what is received on the serial link.
         let received = block!(rx.read()).unwrap();

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-#![deny(unsafe_code)]
 #![no_main]
 #![no_std]
 
@@ -13,7 +11,7 @@ use cortex_m::interrupt::Mutex;
 use cortex_m_rt::entry;
 use stm32l0xx_hal::{
     gpio::*,
-    pac::{self, interrupt, Interrupt},
+    pac::{self, Interrupt},
     prelude::*,
     rcc::Config,
     timer::Timer,
@@ -57,7 +55,6 @@ fn main() -> ! {
     }
 }
 
-#[interrupt]
 fn TIM2() {
     // Keep a state to blink the LED.
     static mut STATE: bool = false;
@@ -69,12 +66,14 @@ fn TIM2() {
 
             // Change the LED state on each interrupt.
             if let Some(ref mut led) = LED.borrow(cs).borrow_mut().deref_mut() {
-                if *STATE {
-                    led.set_low();
-                    *STATE = false;
-                } else {
-                    led.set_high();
-                    *STATE = true;
+                unsafe {
+                    if STATE {
+                        led.set_low();
+                        STATE = false;
+                    } else {
+                        led.set_high();
+                        STATE = true;
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,28 @@
 #![no_std]
 
-#[cfg(not(any(feature = "stm32l0x1")))]
-compile_error!("This crate requires one of the following features enabled: stm32l0x1");
+#[cfg(not(any(feature = "stm32l0x1", feature = "stm32l0x2")))]
+compile_error!("This crate requires one of the following features enabled: stm32l0x1, stm32l0x2");
 
 use embedded_hal as hal;
 
 #[cfg(feature = "stm32l0x1")]
 pub use stm32l0::stm32l0x1 as pac;
+#[cfg(feature = "stm32l0x2")]
+pub use stm32l0::stm32l0x2 as pac;
 
 pub use crate::pac as device;
 pub use crate::pac as stm32;
 
 mod bb;
 
+#[cfg(feature = "stm32l0x1")]
 pub mod adc;
 pub mod delay;
 pub mod exti;
 pub mod gpio;
 pub mod i2c;
 pub mod prelude;
+#[cfg(feature = "stm32l0x1")]
 pub mod pwm;
 pub mod rcc;
 pub mod serial;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,11 +4,13 @@ pub use crate::hal::adc::OneShot as _hal_adc_OneShot;
 pub use crate::hal::watchdog::Watchdog as _hal_watchdog_Watchdog;
 pub use crate::hal::watchdog::WatchdogEnable as _hal_watchdog_WatchdogEnable;
 
+#[cfg(feature = "stm32l0x1")]
 pub use crate::adc::AdcExt as _stm32l0xx_hal_analog_AdcExt;
 pub use crate::delay::DelayExt as _stm32l0xx_hal_delay_DelayExt;
 pub use crate::exti::ExtiExt as _stm32l0xx_hal_exti_ExtiExt;
 pub use crate::gpio::GpioExt as _stm32l0xx_hal_gpio_GpioExt;
 pub use crate::i2c::I2c1Ext as _stm32l0xx_hal_i2c_I2c1Ext;
+#[cfg(feature = "stm32l0x1")]
 pub use crate::pwm::PwmExt as _stm32l0xx_hal_pwm_PwmExt;
 pub use crate::rcc::RccExt as _stm32l0xx_hal_rcc_RccExt;
 pub use crate::serial::Serial1Ext as _stm32l0xx_hal_serial_Serial1Ext;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ptr;
 
-use crate::gpio::gpioa::{PA10, PA2, PA3, PA9};
+use crate::gpio::gpioa::*;
 use crate::gpio::{AltMode, Floating, Input};
 use crate::hal;
 use crate::hal::prelude::*;
@@ -123,17 +123,35 @@ pub trait Pins<USART> {
     fn setup(&self);
 }
 
+#[cfg(feature = "stm32l0x1")]
 impl Pins<USART1> for (PA2<Input<Floating>>, PA3<Input<Floating>>) {
     fn setup(&self) {
-        self.0.set_alt_mode(AltMode::AF6); //AltMode::USART1_3);
-        self.1.set_alt_mode(AltMode::AF6); //AltMode::USART1_3);
+        self.0.set_alt_mode(AltMode::AF6);
+        self.1.set_alt_mode(AltMode::AF6);
     }
 }
 
+#[cfg(feature = "stm32l0x2")]
+impl Pins<USART1> for (PA9<Input<Floating>>, PA10<Input<Floating>>) {
+    fn setup(&self) {
+        self.0.set_alt_mode(AltMode::AF4);
+        self.1.set_alt_mode(AltMode::AF4);
+    }
+}
+
+#[cfg(feature = "stm32l0x1")]
 impl Pins<USART2> for (PA9<Input<Floating>>, PA10<Input<Floating>>) {
     fn setup(&self) {
-        self.0.set_alt_mode(AltMode::AF4); //AltMode::USART1_3);
-        self.1.set_alt_mode(AltMode::AF4); //AltMode::USART1_3);
+        self.0.set_alt_mode(AltMode::AF4);
+        self.1.set_alt_mode(AltMode::AF4);
+    }
+}
+
+#[cfg(feature = "stm32l0x2")]
+impl Pins<USART2> for (PA14<Input<Floating>>, PA15<Input<Floating>>) {
+    fn setup(&self) {
+        self.0.set_alt_mode(AltMode::AF4);
+        self.1.set_alt_mode(AltMode::AF4);
     }
 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,5 +1,7 @@
-use crate::gpio::gpioa::{PA5, PA6, PA7};
-use crate::gpio::{Floating, Input};
+use crate::gpio::gpioa::*;
+use crate::gpio::gpiob::*;
+
+use crate::gpio::{AltMode, Floating, Input};
 use crate::hal;
 use crate::pac::SPI1;
 use crate::rcc::Rcc;
@@ -12,6 +14,8 @@ pub use hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 /// SPI error
 #[derive(Debug)]
 pub enum Error {
+    Busy,
+    FrameError,
     /// Overrun occurred
     Overrun,
     /// Mode fault occurred
@@ -22,10 +26,18 @@ pub enum Error {
     _Extensible,
 }
 
-pub trait Pins<SPI> {}
-pub trait PinSck<SPI> {}
-pub trait PinMiso<SPI> {}
-pub trait PinMosi<SPI> {}
+pub trait Pins<SPI> {
+    fn setup(&self);
+}
+pub trait PinSck<SPI> {
+    fn setup(&self);
+}
+pub trait PinMiso<SPI> {
+    fn setup(&self);
+}
+pub trait PinMosi<SPI> {
+    fn setup(&self);
+}
 
 impl<SPI, SCK, MISO, MOSI> Pins<SPI> for (SCK, MISO, MOSI)
 where
@@ -33,44 +45,96 @@ where
     MISO: PinMiso<SPI>,
     MOSI: PinMosi<SPI>,
 {
+    fn setup(&self) {
+        self.0.setup();
+        self.1.setup();
+        self.2.setup();
+    }
 }
 
 /// A filler type for when the SCK pin is unnecessary
 pub struct NoSck;
+impl NoSck {
+    fn set_alt_mode(&self, some: Option<u32>) {}
+}
 /// A filler type for when the Miso pin is unnecessary
 pub struct NoMiso;
+impl NoMiso {
+    fn set_alt_mode(&self, some: Option<u32>) {}
+}
 /// A filler type for when the Mosi pin is unnecessary
 pub struct NoMosi;
+impl NoMosi {
+    fn set_alt_mode(&self, some: Option<u32>) {}
+}
 
 macro_rules! pins {
-    ($($SPIX:ty: SCK: [$($SCK:ty),*] MISO: [$($MISO:ty),*] MOSI: [$($MOSI:ty),*])+) => {
+    ($($SPIX:ty:
+        SCK: [$([$SCK:ty, $ALTMODESCK:path]),*]
+        MISO: [$([$MISO:ty, $ALTMODEMISO:path]),*]
+        MOSI: [$([$MOSI:ty, $ALTMODEMOSI:path]),*])+) => {
         $(
             $(
-                impl PinSck<$SPIX> for $SCK {}
+                impl PinSck<$SPIX> for $SCK {
+                    fn setup(&self) {
+                        self.set_alt_mode($ALTMODESCK);
+                    }
+                }
             )*
             $(
-                impl PinMiso<$SPIX> for $MISO {}
+                impl PinMiso<$SPIX> for $MISO {
+                    fn setup(&self) {
+                        self.set_alt_mode($ALTMODEMISO);
+                    }
+                }
             )*
             $(
-                impl PinMosi<$SPIX> for $MOSI {}
+                impl PinMosi<$SPIX> for $MOSI {
+                    fn setup(&self) {
+                        self.set_alt_mode($ALTMODEMOSI);
+                    }
+                }
             )*
         )+
     }
 }
 
+#[cfg(feature = "stm32l0x2")]
 pins! {
     SPI1:
         SCK: [
-            NoSck,
-            PA5<Input<Floating>>
+            [NoSck, None],
+            [PB3<Input<Floating>>, AltMode::AF0],
+            [PA5<Input<Floating>>, AltMode::AF0]
         ]
         MISO: [
-            NoMiso,
-            PA6<Input<Floating>>
+            [NoMiso, None],
+            [PA6<Input<Floating>>, AltMode::AF0],
+            [PA11<Input<Floating>>, AltMode::AF0],
+            [PB4<Input<Floating>>, AltMode::AF0]
         ]
         MOSI: [
-            NoMosi,
-            PA7<Input<Floating>>
+            [NoMosi, None],
+            [PA7<Input<Floating>>, AltMode::AF0],
+            [PA12<Input<Floating>>, AltMode::AF0],
+            [PB5<Input<Floating>>, AltMode::AF0]
+        ]
+}
+
+#[cfg(feature = "stm32l0x1")]
+pins! {
+    SPI1:
+        SCK: [
+            [NoSck, None],
+            [PA5<Input<Floating>>, AltMode::AF0]
+        ]
+        MISO: [
+            [NoMiso, None],
+            [PA6<Input<Floating>>, AltMode::AF0]
+        ]
+        MOSI: [
+            [NoMosi, None],
+            [PA7<Input<Floating>>, AltMode::AF0]
         ]
 }
 
@@ -102,6 +166,8 @@ macro_rules! spi {
                 PINS: Pins<$SPIX>,
                 T: Into<Hertz>
                 {
+                    pins.setup();
+
                     // Enable clock for SPI
                     rcc.rb.$apbXenr.modify(|_, w| w.$spiXen().set_bit());
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,3 @@
-use cortex_m::peripheral::DWT;
-
 #[derive(PartialEq, PartialOrd, Clone, Copy)]
 pub struct Bps(pub u32);
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,3 +1,4 @@
+
 //! Timers
 use crate::hal::timer::{CountDown, Periodic};
 use cast::{u16, u32};
@@ -152,7 +153,11 @@ macro_rules! timers {
                     let psc = u16((ticks - 1) / (1 << 16)).unwrap();
 
                     self.tim.psc.write(|w| unsafe { w.psc().bits(psc) });
+                    #[cfg(feature = "stm32l0x1")]
                     self.tim.arr.write(|w| unsafe { w.arr().bits( u16(ticks / u32(psc + 1)).unwrap() ) });
+                    #[cfg(feature = "stm32l0x2")]
+                    self.tim.arr.write(|w| unsafe { w.arr().bits( u16(ticks / u32(psc + 1)).unwrap().into() ) });
+
 
                     self.tim.cr1.modify(|_, w| w.urs().set_bit());
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
@@ -173,9 +178,17 @@ macro_rules! timers {
     }
 }
 
+#[cfg(feature = "stm32l0x1")]
 timers! {
     TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr, apb1_tim_clk),
     TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr, apb1_tim_clk),
     TIM21: (tim21, tim21en, tim21rst, apb2enr, apb2rstr, apb2_tim_clk),
     TIM22: (tim22, tim22en, tim22rst, apb2enr, apb2rstr, apb2_tim_clk),
+}
+#[cfg(feature = "stm32l0x2")]
+timers! {
+    TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr, apb1_tim_clk),
+    TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr, apb1_tim_clk),
+    TIM21: (tim21, tim21en, tim21rst, apb2enr, apb2rstr, apb2_tim_clk),
+    //TODO: figure out why I had to remove TIM22 from stm32l0x2 (lthiery)
 }


### PR DESCRIPTION
I've added in minimal support for the stm32l0x2. In particular, I've tested UART and SPI and done some pin-to-AF mappings for the chip.

In an effort to get SPI working I added in the alternate function configuration of the pins to the driver, similar to how it was done in UART.

Also, it appears that embedded-hal is deprecating the pin interfaces that this project uses, so there's a flood of warnings about that. I may be able to try to resolve that but just wanted to give you a heads up.