### PR TITLE
exti implemented to work on multiple ports. resolve pwm conflicts wit…

### DIFF
--- a/examples/button_irq.rs
+++ b/examples/button_irq.rs
@@ -35,9 +35,23 @@ fn main() -> ! {
     // Configure PB6 as output.
     let led = gpiob.pb6.into_push_pull_output();
 
+    // Configure PB2 as input.
+    let button = gpiob.pb2.into_pull_up_input();
+
+    #[cfg(feature = "stm32l0x1")]
+    let mut syscfg = dp.SYSCFG;
+    #[cfg(feature = "stm32l0x2")]
+    let mut syscfg = dp.SYSCFG_COMP;
+
     // Configure the external interrupt on the falling edge for the pin 0.
     let exti = dp.EXTI;
-    exti.listen(0, TriggerEdge::Falling);
+    exti.listen(
+        &mut rcc,
+        &mut syscfg,
+        button.port,
+        button.i,
+        TriggerEdge::Falling,
+    );
 
     // Store the external interrupt and LED in mutex reffcells to make them
     // available from the interrupt.

--- a/examples/button_irq_rtfm.rs
+++ b/examples/button_irq_rtfm.rs
@@ -25,9 +25,23 @@ const APP: () = {
         // Configure PB6 as output.
         let led = gpiob.pb6.into_push_pull_output();
 
+        // Configure PB2 as input.
+        let button = gpiob.pb2.into_pull_up_input();
+    
+        #[cfg(feature = "stm32l0x1")]
+        let mut syscfg = device.SYSCFG;
+        #[cfg(feature = "stm32l0x2")]
+        let mut syscfg = device.SYSCFG_COMP;
+
         // Configure the external interrupt on the falling edge for the pin 0.
         let exti = device.EXTI;
-        exti.listen(0, TriggerEdge::Falling);
+        exti.listen(
+            &mut rcc,
+            &mut syscfg,
+            button.port,
+            button.i,
+            TriggerEdge::Falling,
+        );
 
         // Return the initialised resources.
         init::LateResources {

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -1,3 +1,4 @@
+  
 #![deny(warnings)]
 #![deny(unsafe_code)]
 #![no_main]
@@ -22,20 +23,19 @@ fn main() -> ! {
     // the RCC register.
     let gpioa = dp.GPIOA.split(&mut rcc);
 
+    #[cfg(feature = "stm32l0x1")]
     let tx_pin = gpioa.pa9;
+    #[cfg(feature = "stm32l0x1")]
     let rx_pin = gpioa.pa10;
 
-    // Configure the serial peripheral.
-    #[cfg(feature = "stm32l0x1")]
-    let serial = dp
-        .USART2
-        .usart((tx_pin, rx_pin), serial::Config::default(), &mut rcc)
-        .unwrap();
+    #[cfg(feature = "stm32l0x2")]
+    let tx_pin = gpioa.pa14;
+    #[cfg(feature = "stm32l0x2")]
+    let rx_pin = gpioa.pa15;
 
     // Configure the serial peripheral.
-    #[cfg(feature = "stm32l0x2")]
     let serial = dp
-        .USART1
+        .USART2
         .usart((tx_pin, rx_pin), serial::Config::default(), &mut rcc)
         .unwrap();
 

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -1,6 +1,14 @@
 //! External interrupt controller
 use crate::bb;
 use crate::pac::EXTI;
+use crate::gpio;
+use crate::rcc;
+use crate::rcc::Rcc;
+
+#[cfg(feature = "stm32l0x1")]
+use stm32l0::stm32l0x1::SYSCFG as syscfg_comp;
+#[cfg(feature = "stm32l0x2")]
+use stm32l0::stm32l0x2::SYSCFG_COMP as syscfg_comp;
 
 pub enum TriggerEdge {
     Rising,
@@ -9,24 +17,105 @@ pub enum TriggerEdge {
 }
 
 pub trait ExtiExt {
-    fn listen(&self, line: u8, edge: TriggerEdge);
-    fn unlisten(&self, line: u8);
-    fn pend_interrupt(&self, line: u8);
-    fn clear_irq(&self, line: u8);
+  fn listen(&self, rcc: &mut Rcc, syscfg: &mut syscfg_comp, port: gpio::Port, line: u8, edge: TriggerEdge);
+  fn unlisten(&self, line: u8);
+  fn pend_interrupt(&self, line: u8);
+  fn clear_irq(&self, line: u8);
 }
 
 impl ExtiExt for EXTI {
-    fn listen(&self, line: u8, edge: TriggerEdge) {
+    fn listen(&self, rcc: &mut Rcc, syscfg: &mut syscfg_comp, port: gpio::Port, line: u8, edge: TriggerEdge) {
+        #[cfg(feature = "stm32l0x1")]
         assert!(line < 24);
-        match edge {
-            TriggerEdge::Rising => bb::set(&self.rtsr, line),
-            TriggerEdge::Falling => bb::set(&self.ftsr, line),
-            TriggerEdge::All => {
-                bb::set(&self.rtsr, line);
-                bb::set(&self.ftsr, line);
-            }
+        #[cfg(feature = "stm32l0x2")]
+        assert!(line < 15);
+
+        // ensure that the SYSCFG peripheral is powered on
+        // SYSCFG is necessary to change which PORT is routed to EXTIn
+        rcc.enable(rcc::Peripheral::SYSCFG);
+
+        // translate port into bit values for EXTIn registers
+        let port_bm = match port {
+            gpio::Port::PA => 0,
+            gpio::Port::PB => 1,
+            gpio::Port::PC => 2,
+            gpio::Port::PD => 2,
+        };
+
+        unsafe {
+            match line {
+                0 | 1 | 2 | 3 => {
+                    syscfg.exticr1.modify(|_, w| {
+                        match line {
+                            0 => w.exti0().bits(port_bm),
+                            1 => w.exti1().bits(port_bm),
+                            2 => w.exti2().bits(port_bm),
+                            3 => w.exti3().bits(port_bm),
+                            _ => w,
+                        }
+                    });
+                },
+                4 | 5 | 6 | 7 => {
+                    syscfg.exticr2.modify(|_, w| {
+                        match line {
+                            4 => w.exti4().bits(port_bm),
+                            5 => w.exti5().bits(port_bm),
+                            6 => w.exti6().bits(port_bm),
+                            7 => w.exti7().bits(port_bm),
+                            _ => w,
+                        }
+                    });
+                },
+                8 | 9 | 10 | 11 => {
+                    syscfg.exticr3.modify(|_, w| {
+                        match line {
+                            8 => w.exti8().bits(port_bm),
+                            9 => w.exti9().bits(port_bm),
+                            10 => w.exti10().bits(port_bm),
+                            11 => w.exti11().bits(port_bm),
+                            _ => w,
+                        }
+                    });
+                },
+                12 | 13 | 14 | 15 => {
+                    syscfg.exticr4.modify(|_, w| {
+                        match line {
+                            12 => w.exti12().bits(port_bm),
+                            13 => w.exti13().bits(port_bm),
+                            14 => w.exti14().bits(port_bm),
+                            15 => w.exti15().bits(port_bm),
+                            _ => w,
+                        }
+                    });
+                },
+                 _ => (),
+            };
         }
-        bb::set(&self.imr, line);
+
+        let bm: u32 = 0b1<<line;
+
+        unsafe {
+            match edge {
+                TriggerEdge::Rising => self.rtsr.modify(|_, w|
+                    w.bits(bm)
+                ),
+                TriggerEdge::Falling => self.ftsr.modify(|_, w|
+                    w.bits(bm)
+                ),
+                TriggerEdge::All => {
+                    self.rtsr.modify(|_, w|
+                        w.bits(bm)
+                    );
+                    self.ftsr.modify(|_, w|
+                        w.bits(bm)
+                    );
+                    }
+            }
+
+            self.imr.modify(|_, w|
+                w.bits(bm)
+            );
+        }
     }
 
     fn unlisten(&self, line: u8) {
@@ -43,6 +132,11 @@ impl ExtiExt for EXTI {
 
     fn clear_irq(&self, line: u8) {
         assert!(line < 24);
-        bb::set(&self.pr, line);
+
+        self.pr.write(|w|
+            unsafe{
+                w.bits(0b1<<line)
+            }
+        );
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -2,12 +2,10 @@
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 
 use cast::u8;
-use core::cmp;
 use crate::gpio::gpioa::{PA4, PA9, PA10, PA13};
 use crate::gpio::gpiob::{PB6, PB7};
 use crate::gpio::{AltMode, OpenDrain, Output};
 use crate::pac::I2C1;
-use crate::prelude::*;
 use crate::rcc::Rcc;
 use crate::time::Hertz;
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -60,15 +60,18 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() }
+                unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 }
             }
 
             fn get_max_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
+                unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16}
             }
 
             fn set_duty(&mut self, duty: u16) {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty)) }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty as u32)) }
             }
         }
     };
@@ -143,15 +146,24 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 }
             }
 
             fn get_max_duty(&self) -> u16 {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
             }
 
             fn set_duty(&mut self, duty: u16) {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty)) }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty as u32))}
             }
         }
 
@@ -174,15 +186,18 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() }
+                unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() as u16 }
             }
 
             fn get_max_duty(&self) -> u16 {
-                unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
+                unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16}
             }
 
             fn set_duty(&mut self, duty: u16) {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty)) }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty as u32)) }
             }
         }
 
@@ -205,15 +220,24 @@ macro_rules! channels {
             }
 
             fn get_duty(&self) -> u16 {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() as u16 }
             }
 
             fn get_max_duty(&self) -> u16 {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).arr.read().arr().bits() }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
             }
 
             fn set_duty(&mut self, duty: u16) {
+                #[cfg(feature = "stm32l0x1")]
                 unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty)) }
+                #[cfg(feature = "stm32l0x2")]
+                unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty as u32)) }
             }
         }
     };
@@ -258,7 +282,10 @@ macro_rules! timers {
                 let arr = u16(ticks / u32(psc + 1)).unwrap();
                 tim.psc.write(|w| unsafe { w.psc().bits(psc) });
                 #[allow(unused_unsafe)]
+                #[cfg(feature = "stm32l0x1")]
                 tim.arr.write(|w| unsafe { w.arr().bits(arr) });
+                #[cfg(feature = "stm32l0x2")]
+                tim.arr.write(|w| unsafe { w.arr().bits(arr as u32) });
                 tim.cr1.write(|w| w.cen().set_bit());
                 unsafe { mem::uninitialized() }
             }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -169,6 +169,45 @@ pub struct Rcc {
     pub(crate) rb: RCC,
 }
 
+pub enum Peripheral {
+    // CRS,
+    // DAC,
+    // I2C1,
+    // I2C2,
+    // I2C3,
+    // LPTIME1,
+    // LPUART1,
+    // PWREN,
+    // SPI2EN,
+    // TIM2EN,
+    // TIM3EN,
+    // USART2,
+    // USART4,
+    // USART5,
+    // USB,
+    // ADC,
+    // DBG,
+    // MIFI,
+    // SPI,
+    SYSCFG,
+    // TIM21,
+    // TIM22,
+    // UART1
+}
+
+impl Rcc {
+    pub fn enable(&self, p: Peripheral) {
+        match p {
+            Peripheral::SYSCFG => {
+                self.rb.apb2enr.modify(|_, w| {
+                    w.syscfgen().bit(true)
+                });
+            }
+        }
+        
+    }
+}
+
 /// Extension trait that freezes the `RCC` peripheral with provided clocks configuration
 pub trait RccExt {
     fn freeze(self, config: Config) -> Rcc;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -132,7 +132,7 @@ impl Pins<USART1> for (PA2<Input<Floating>>, PA3<Input<Floating>>) {
 }
 
 #[cfg(feature = "stm32l0x2")]
-impl Pins<USART1> for (PA9<Input<Floating>>, PA10<Input<Floating>>) {
+impl Pins<USART2> for (PA2<Input<Floating>>, PA3<Input<Floating>>) {
     fn setup(&self) {
         self.0.set_alt_mode(AltMode::AF4);
         self.1.set_alt_mode(AltMode::AF4);
@@ -241,14 +241,14 @@ macro_rules! usart {
                             })
                     });
 
-                    usart.cr2.write(|w| unsafe {
+                    usart.cr2.write(|w| 
                         w.stop().bits(match config.stopbits {
                             StopBits::STOP1 => 0b00,
                             StopBits::STOP0P5 => 0b01,
                             StopBits::STOP2 => 0b10,
                             StopBits::STOP1P5 => 0b11,
                         })
-                    });
+                    );
                     Ok(Serial {
                         usart,
                         tx: Tx { _usart: PhantomData },
@@ -289,7 +289,7 @@ macro_rules! usart {
                 /// Clears interrupt flag
                 pub fn clear_irq(&mut self, event: Event) {
                     if let Event::Rxne = event {
-                        self.usart.rqr.write(|w| unsafe { w.rxfrq().discard() })
+                        self.usart.rqr.write(|w| w.rxfrq().discard())
                     }
                 }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,4 +1,5 @@
 use crate::gpio::gpioa::*;
+#[cfg(feature = "stm32l0x2")]
 use crate::gpio::gpiob::*;
 
 use crate::gpio::{AltMode, Floating, Input};
@@ -55,17 +56,17 @@ where
 /// A filler type for when the SCK pin is unnecessary
 pub struct NoSck;
 impl NoSck {
-    fn set_alt_mode(&self, some: Option<u32>) {}
+    fn set_alt_mode(&self, _some: Option<u32>) {}
 }
 /// A filler type for when the Miso pin is unnecessary
 pub struct NoMiso;
 impl NoMiso {
-    fn set_alt_mode(&self, some: Option<u32>) {}
+    fn set_alt_mode(&self, _some: Option<u32>) {}
 }
 /// A filler type for when the Mosi pin is unnecessary
 pub struct NoMosi;
 impl NoMosi {
-    fn set_alt_mode(&self, some: Option<u32>) {}
+    fn set_alt_mode(&self, _some: Option<u32>) {}
 }
 
 macro_rules! pins {


### PR DESCRIPTION
For exti to work on different ports, you need to change a setting in the SYSCFG EXTI_CR register. To be able to do that, you need to make sure RCC has been enabled for SYSCFG. That required a lot more params for `exti.listen`. 

I think there are a lot of params for the `listen` function now, but I don't want to push responsibility of doing rcc enable for the SYSCFG to the client, for example. Maybe there will be a higher level `system manager` concept that will emerge that can hold RCC and SYSCFG and things like that... We'll see.

Also, you'll note that I added `port: gpio::Port, line: u8` to the definition of the GPIO struct. That will make it somewhat easier to use, but I wish we could just pass a reference to the GPIO. And maybe we could "into" those structs into a port in pin definition based on the hardware address. I didn't have time to refine that idea either though and this implementation is just fine for now, I think.

As I was merging the work with master, lots of type conflicts (u16 where u32 where expected for the stm32l0x2) occurred. I can only assume the stm32l0x2 has more timers/pwms available and so where you use "bits" I need to indicate which timer. Or perhaps 32 bit timers are available. Either way, I just "made it compile for now" and will test it when I get to PWM.