### PR TITLE
Add DMA support to AES module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ version = "0.1.7"
 features = ["stm32l0x1", "stm32l0x2", "rt"]
 
 [dependencies]
+as-slice = "0.1.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 cortex-m = {version = "0.5.8", features = ["const-fn"] }
 cortex-m-rt = "0.6.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ name = "aes"
 required-features = ["stm32l082"]
 
 [[example]]
+name = "aes-dma"
+required-features = ["stm32l082"]
+
+[[example]]
 name = "button_irq"
 required-features = ["rt"]
 

--- a/examples/aes-dma.rs
+++ b/examples/aes-dma.rs
@@ -1,0 +1,114 @@
+//! Encryption/decryption using the AES peripheral
+
+
+#![no_main]
+#![no_std]
+
+
+extern crate panic_semihosting;
+
+
+use core::pin::Pin;
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    prelude::*,
+    aes::AES,
+    dma::DMA,
+    pac,
+    rcc::Config,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcc = dp.RCC.freeze(Config::hsi16());
+    let mut aes = AES::new(dp.AES, &mut rcc);
+    let mut dma = DMA::new(dp.DMA1, &mut rcc);
+
+    let key = [0x01234567, 0x89abcdef, 0x01234567, 0x89abcdef];
+    let ivr = [0xfedcba98, 0x76543210, 0xfedcba98];
+
+    const DATA: [u32; 8] = [
+        0x00112233,
+        0x44556677,
+        0x8899aabb,
+        0xccddeeff,
+
+        0x00112233,
+        0x44556677,
+        0x8899aabb,
+        0xccddeeff,
+    ];
+    let data = Pin::new(&DATA);
+
+    static mut ENCRYPTED: [u32; 8] = [0; 8];
+    static mut DECRYPTED: [u32; 8] = [0; 8];
+
+    // Prepare DMA buffers. This is safe, as this is the `main` function, and no
+    // other functions have access to these statics.
+    let mut encrypted = Pin::new(unsafe { &mut ENCRYPTED });
+    let mut decrypted = Pin::new(unsafe { &mut DECRYPTED });
+
+    loop {
+        let mut ctr_stream = aes.start_ctr_stream(key, ivr);
+        let tx_transfer = ctr_stream.tx
+            .write_all(
+                &mut dma.handle,
+                data,
+                dma.channels.channel1,
+            )
+            .start();
+        let rx_transfer = ctr_stream.rx
+            .read_all(
+                &mut dma.handle,
+                encrypted,
+                dma.channels.channel2,
+            )
+            .start();
+
+        let tx_res = tx_transfer.wait().unwrap();
+        let rx_res = rx_transfer.wait().unwrap();
+
+        ctr_stream.tx         = tx_res.target;
+        ctr_stream.rx         = rx_res.target;
+        dma.channels.channel1 = tx_res.channel;
+        dma.channels.channel2 = rx_res.channel;
+        encrypted             = rx_res.buffer;
+        aes                   = ctr_stream.finish();
+
+        assert_ne!(encrypted, Pin::new(&mut [0; 8]));
+        assert_ne!(encrypted, data);
+
+        let mut ctr_stream = aes.start_ctr_stream(key, ivr);
+        let tx_transfer = ctr_stream.tx
+            .write_all(
+                &mut dma.handle,
+                encrypted,
+                dma.channels.channel1,
+            )
+            .start();
+        let rx_transfer = ctr_stream.rx
+            .read_all(
+                &mut dma.handle,
+                decrypted,
+                dma.channels.channel2,
+            )
+            .start();
+
+        let tx_res = tx_transfer.wait().unwrap();
+        let rx_res = rx_transfer.wait().unwrap();
+
+        ctr_stream.tx         = tx_res.target;
+        ctr_stream.rx         = rx_res.target;
+        dma.channels.channel1 = tx_res.channel;
+        dma.channels.channel2 = rx_res.channel;
+        encrypted             = tx_res.buffer;
+        decrypted             = rx_res.buffer;
+        aes                   = ctr_stream.finish();
+
+        assert_eq!(decrypted, data);
+    }
+}

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -3,6 +3,16 @@
 //! See STM32L0x2 Reference Manual, chapter 11.
 
 
+// Currently the only module using DMA is STM32L082-only, which leads to unused
+// warnings when compiling for STM32L0x2. Rather than making the whole DMA
+// module STM32L082-only, which wouldn't reflect the reality, I've added this
+// stopgap measure to silence the warnings.
+//
+// This should be removed once there are any STM32L0x2 modules making use of
+// DMA.
+#![cfg_attr(not(feature = "stm32l082"), allow(unused, unused_macros))]
+
+
 use core::{
     fmt,
     ops::{
@@ -28,6 +38,9 @@ use crate::{
     },
     rcc::Rcc,
 };
+
+#[cfg(feature = "stm32l082")]
+use crate::aes;
 
 
 /// Entry point to the DMA API
@@ -437,7 +450,13 @@ macro_rules! impl_target {
 }
 
 // See STM32L0x2 Reference Manual, table 51 (page 267).
-impl_target!();
+#[cfg(feature = "stm32l082")]
+impl_target!(
+    aes::Tx, Channel1, 11;
+    aes::Tx, Channel5, 11;
+    aes::Rx, Channel2, 11;
+    aes::Rx, Channel3, 11;
+);
 
 
 /// Indicates that a DMA transfer is ready

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1,0 +1,436 @@
+//! Interface to the DMA peripheral
+//!
+//! See STM32L0x2 Reference Manual, chapter 11.
+
+
+use core::{
+    fmt,
+    ops::{
+        Deref,
+        DerefMut,
+    },
+    pin::Pin,
+    sync::atomic::{
+        compiler_fence,
+        Ordering,
+    }
+};
+
+use as_slice::{
+    AsMutSlice,
+    AsSlice,
+};
+
+use crate::{
+    pac::{
+        self,
+        dma1::ccr1,
+    },
+    rcc::Rcc,
+};
+
+
+/// Entry point to the DMA API
+pub struct DMA {
+    /// Handle to the DMA peripheral
+    pub handle: Handle,
+
+    /// DMA channels
+    pub channels: Channels
+}
+
+impl DMA {
+    /// Create an instance of the DMA API
+    pub fn new(dma: pac::DMA1, rcc: &mut Rcc) -> Self {
+        // Reset peripheral
+        rcc.rb.ahbrstr.modify(|_, w| w.dmarst().set_bit());
+        rcc.rb.ahbrstr.modify(|_, w| w.dmarst().clear_bit());
+
+        // Enable peripheral clock
+        rcc.rb.ahbenr.modify(|_, w| w.dmaen().set_bit());
+
+        Self {
+            handle:   Handle { dma },
+            channels: Channels::new(),
+        }
+    }
+}
+
+
+/// Handle to the DMA peripheral
+pub struct Handle {
+    dma: pac::DMA1,
+}
+
+
+pub struct Transfer<C, T, B, State> {
+    res:    TransferResources<C, T, B>,
+    _state: State,
+}
+
+impl<T, C, B> Transfer<T, C, B, Ready>
+    where
+        T: Target<C>,
+        C: Channel,
+{
+    pub(crate) fn memory_to_peripheral(
+        handle:  &mut Handle,
+        target:  T,
+        channel: C,
+        buffer:  Pin<B>,
+        address: u32,
+    )
+        -> Self
+        where
+            B:         Deref,
+            B::Target: AsSlice<Element=u8>,
+    {
+        // Safe, because the traits bounds of this method guarantee that
+        // `buffer` can be read from.
+        unsafe {
+            Self::new(
+                handle,
+                target,
+                channel,
+                buffer,
+                address,
+                ccr1::DIRW::FROMMEMORY,
+            )
+        }
+    }
+
+    pub(crate) fn peripheral_to_memory(
+        handle:  &mut Handle,
+        target:  T,
+        channel: C,
+        buffer:  Pin<B>,
+        address: u32,
+    )
+        -> Self
+        where
+            B:         DerefMut,
+            B::Target: AsMutSlice<Element=u8>,
+    {
+        // Safe, because the traits bounds of this method guarantee that
+        // `buffer` can be written to.
+        unsafe {
+            Self::new(
+                handle,
+                target,
+                channel,
+                buffer,
+                address,
+                ccr1::DIRW::FROMPERIPHERAL,
+            )
+        }
+    }
+
+    /// Internal constructor
+    ///
+    /// # Safety
+    ///
+    /// If this is used to prepare a memory-to-peripheral transfer, the caller
+    /// must make sure that the buffer can be read from safely.
+    ///
+    /// If this is used to prepare a peripheral-to-memory transfer, the caller
+    /// must make sure that the buffer can be written to safely.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the length of the buffer is larger than `u16::max_value()`.
+    unsafe fn new(
+        handle:  &mut Handle,
+        target:  T,
+        channel: C,
+        buffer:  Pin<B>,
+        address: u32,
+        dir:     ccr1::DIRW,
+    )
+        -> Self
+        where
+            B:         Deref,
+            B::Target: AsSlice<Element=u8>,
+    {
+        assert!(buffer.as_slice().len() <= u16::max_value() as usize);
+
+        channel.select_target(handle, &target);
+        channel.set_peripheral_address(handle, address);
+        channel.set_memory_address(handle, buffer.as_slice().as_ptr() as u32);
+        channel.set_transfer_len(handle, buffer.as_slice().len() as u16);
+        channel.configure(handle, dir);
+
+        Transfer {
+            res: TransferResources {
+                target,
+                channel,
+                buffer,
+            },
+            _state: Ready,
+        }
+    }
+
+    pub fn start(self) -> Transfer<T, C, B, Started> {
+        compiler_fence(Ordering::SeqCst);
+
+        self.res.channel.start();
+
+        Transfer {
+            res:    self.res,
+            _state: Started,
+        }
+    }
+}
+
+impl<T, C, B> Transfer<T, C, B, Started>
+    where C: Channel
+{
+    /// Indicates whether the transfer is still ongoing
+    pub fn is_active(&self) -> bool {
+        self.res.channel.is_active()
+    }
+
+    /// Waits for the transfer to finish and return owned resources
+    ///
+    /// This function will busily wait until the transfer is finished. If you
+    /// don't want this, please call this function only once you know that the
+    /// transfer has finished.
+    ///
+    /// This function will return immediately, if [`Transfer::is_active`]
+    /// returns `false`.
+    pub fn wait(self)
+        -> Result<
+            TransferResources<T, C, B>,
+            (TransferResources<T, C, B>, Error)
+        >
+    {
+        while self.is_active() {
+            if self.res.channel.error_occured() {
+                return Err((self.res, Error));
+            }
+        }
+
+        compiler_fence(Ordering::SeqCst);
+
+        if self.res.channel.error_occured() {
+            return Err((self.res, Error));
+        }
+
+        Ok(self.res)
+    }
+}
+
+
+pub struct TransferResources<T, C, B> {
+    pub target:  T,
+    pub channel: C,
+    pub buffer:  Pin<B>,
+}
+
+// Since `TransferResources` is used in the error variant of a `Result`, it
+// needs to implement `Debug` for methods like `unwrap` to work. We can't just
+// derive `Debug`, without requiring all type parameters to be `Debug`, which
+// seems to restrictive.
+impl<T, C, B> fmt::Debug for TransferResources<T, C, B> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TransferResources {{ ... }}")
+    }
+}
+
+
+#[derive(Debug)]
+pub struct Error;
+
+
+pub trait Channel: Sized {
+    fn select_target<T: Target<Self>>(&self, _: &mut Handle, target: &T);
+    fn set_peripheral_address(&self, _: &mut Handle, address: u32);
+    fn set_memory_address(&self, _: &mut Handle, address: u32);
+    fn set_transfer_len(&self, _: &mut Handle, len: u16);
+    fn configure(&self, _: &mut Handle, dir: ccr1::DIRW);
+    fn start(&self);
+    fn is_active(&self) -> bool;
+    fn error_occured(&self) -> bool;
+}
+
+macro_rules! impl_channel {
+    (
+        $(
+            $channel:ident,
+            $field:ident,
+            $cxs:ident,
+            $cpar:ident,
+            $cmar:ident,
+            $cndtr:ident,
+            $ccr:ident,
+            $tcif:ident,
+            $teif:ident,
+            $ctcif:ident,
+            $cteif:ident;
+        )*
+    ) => {
+        pub struct Channels {
+            $(pub $field: $channel,)*
+        }
+
+        impl Channels {
+            pub fn new() -> Self {
+                Self {
+                    $($field: $channel(()),)*
+                }
+            }
+        }
+
+        $(
+            pub struct $channel(());
+
+            impl Channel for $channel {
+                fn select_target<T: Target<Self>>(&self,
+                    handle:  &mut Handle,
+                    _target: &T,
+                ) {
+                    handle.dma.cselr.modify(|_, w| w.$cxs().bits(T::REQUEST));
+                }
+
+                fn set_peripheral_address(&self,
+                    handle:  &mut Handle,
+                    address: u32,
+                ) {
+                    handle.dma.$cpar.write(|w| w.pa().bits(address));
+                }
+
+                fn set_memory_address(&self,
+                    handle:  &mut Handle,
+                    address: u32,
+                ) {
+                    handle.dma.$cmar.write(|w| w.ma().bits(address));
+                }
+
+                fn set_transfer_len(&self, handle: &mut Handle, len: u16) {
+                    handle.dma.$cndtr.write(|w| w.ndt().bits(len));
+                }
+
+                fn configure(&self,
+                    handle: &mut Handle,
+                    dir:    ccr1::DIRW,
+                ) {
+                    // TASK: MSIZE and PSIZE are incorrect. Should be 32 bits.
+                    handle.dma.$ccr.write(|w|
+                        w
+                            // Memory-to-memory mode disabled
+                            .mem2mem().disabled()
+                            // Low priority
+                            .pl().low()
+                            // Word size in memory
+                            .msize().bit8()
+                            // Word size in peripheral
+                            .psize().bit8()
+                            // Increment memory pointer
+                            .minc().enabled()
+                            // Don't increment peripheral pointer
+                            .pinc().disabled()
+                            // Circular mode disabled
+                            .circ().disabled()
+                            // Data transfer direction
+                            .dir().bit(dir._bits())
+                            // Disable interrupts
+                            .teie().disabled()
+                            .htie().disabled()
+                            .tcie().disabled()
+                    );
+                }
+
+                fn start(&self) {
+                    // Safe, because we're only accessing a register that this
+                    // channel has exclusive access to.
+                    let ccr = &unsafe { &*pac::DMA1::ptr() }.$ccr;
+
+                    // Start transfer
+                    ccr.modify(|_, w| w.en().enabled());
+                }
+
+                fn is_active(&self) -> bool {
+                    // This is safe, for the following reasons:
+                    // - We only do one atomic read of ISR.
+                    // - IFCR is a stateless register and we don one atomic
+                    //   write.
+                    // - This channel has exclusive access to CCRx.
+                    let dma = unsafe { &*pac::DMA1::ptr() };
+
+                    if dma.isr.read().$tcif().is_complete() {
+                        dma.ifcr.write(|w| w.$ctcif().set_bit());
+                        dma.$ccr.modify(|_, w| w.en().disabled());
+                        false
+                    }
+                    else {
+                        true
+                    }
+                }
+
+                fn error_occured(&self) -> bool {
+                    // This is safe, for the following reasons:
+                    // - We only do one atomic read of ISR.
+                    // - IFCR is a stateless register and we don one atomic
+                    //   write.
+                    let dma = unsafe { &*pac::DMA1::ptr() };
+
+                    if dma.isr.read().$teif().is_error() {
+                        dma.ifcr.write(|w| w.$cteif().set_bit());
+                        true
+                    }
+                    else {
+                        false
+                    }
+                }
+            }
+        )*
+    }
+}
+
+impl_channel!(
+    Channel1, channel1,
+        c1s, cpar1, cmar1, cndtr1, ccr1,
+        tcif1, teif1, ctcif1, cteif1;
+    Channel2, channel2,
+        c2s, cpar2, cmar2, cndtr2, ccr2,
+        tcif2, teif2, ctcif2, cteif2;
+    Channel3, channel3,
+        c3s, cpar3, cmar3, cndtr3, ccr3,
+        tcif3, teif3, ctcif3, cteif3;
+    Channel4, channel4,
+        c4s, cpar4, cmar4, cndtr4, ccr4,
+        tcif4, teif4, ctcif4, cteif4;
+    Channel5, channel5,
+        c5s, cpar5, cmar5, cndtr5, ccr5,
+        tcif5, teif5, ctcif5, cteif5;
+    Channel6, channel6,
+        c6s, cpar6, cmar6, cndtr6, ccr6,
+        tcif6, teif6, ctcif6, cteif6;
+    Channel7, channel7,
+        c7s, cpar7, cmar7, cndtr7, ccr7,
+        tcif7, teif7, ctcif7, cteif7;
+);
+
+
+pub trait Target<Channel> {
+    const REQUEST: u8;
+}
+
+macro_rules! impl_target {
+    ($($target:ty, $channel:ty, $request:expr;)*) => {
+        $(
+            impl Target<$channel> for $target {
+                const REQUEST: u8 = $request;
+            }
+        )*
+    }
+}
+
+// See STM32L0x2 Reference Manual, table 51 (page 267).
+impl_target!();
+
+
+/// Indicates that a DMA transfer is ready
+pub struct Ready;
+
+/// Indicates that a DMA transfer has been started
+pub struct Started;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod adc;
 #[cfg(any(feature = "stm32l062", feature = "stm32l082"))]
 pub mod aes;
 pub mod delay;
+#[cfg(feature = "stm32l0x2")]
+pub mod dma;
 pub mod exti;
 pub mod gpio;
 pub mod i2c;


### PR DESCRIPTION
Also adds a generic DMA module that can be reused by other peripheral APIs.

This pull request is based on #13. I recommend reviewing and merging that pull request before this one.