### PR TITLE
Make DMA-based AES API more ergonomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ nb = "0.1.2"
 version = "0.7.0"
 
 [dev-dependencies]
+aligned = "0.3.1"
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.1"
 

--- a/examples/aes-dma.rs
+++ b/examples/aes-dma.rs
@@ -42,21 +42,21 @@ fn main() -> ! {
     let key = [0x01234567, 0x89abcdef, 0x01234567, 0x89abcdef];
     let ivr = [0xfedcba98, 0x76543210, 0xfedcba98];
 
-    const DATA: [u32; 8] = [
-        0x00112233,
-        0x44556677,
-        0x8899aabb,
-        0xccddeeff,
+    const DATA: [u8; 32] = [
+        0x00, 0x11, 0x22, 0x33,
+        0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb,
+        0xcc, 0xdd, 0xee, 0xff,
 
-        0x00112233,
-        0x44556677,
-        0x8899aabb,
-        0xccddeeff,
+        0x00, 0x11, 0x22, 0x33,
+        0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb,
+        0xcc, 0xdd, 0xee, 0xff,
     ];
     let data = Pin::new(&DATA);
 
-    static mut ENCRYPTED: [u32; 8] = [0; 8];
-    static mut DECRYPTED: [u32; 8] = [0; 8];
+    static mut ENCRYPTED: [u8; 32] = [0; 32];
+    static mut DECRYPTED: [u8; 32] = [0; 32];
 
     // Prepare DMA buffers. This is safe, as this is the `main` function, and no
     // other functions have access to these statics.
@@ -112,7 +112,7 @@ fn main() -> ! {
         encrypted             = rx_res.buffer;
         aes                   = ctr_stream.finish();
 
-        assert_ne!(encrypted, Pin::new(&mut [0; 8]));
+        assert_ne!(encrypted, Pin::new(&mut [0; 32]));
         assert_ne!(encrypted, data);
 
         let mut ctr_stream = aes.start_ctr_stream(key, ivr);

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -384,6 +384,7 @@ impl<Target, Channel, Buffer> Transfer<Target, Channel, Buffer, dma::Ready>
                 len: buffer.as_slice().len() / 4,
             }),
             address,
+            dma::Priority::low(),
             dir,
         );
 

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -219,7 +219,18 @@ impl Tx {
         // Safe, because we're only taking the address of a register.
         let address = &unsafe { &*pac::AES::ptr() }.dinr as *const _ as u32;
 
-        dma::Transfer::memory_to_peripheral(dma, self, channel, buffer, address)
+        // Safe, because the traits bounds of this method guarantee that
+        // `buffer` can be read from.
+        unsafe {
+            dma::Transfer::new(
+                dma,
+                self,
+                channel,
+                buffer,
+                address,
+                dma::Direction::memory_to_peripheral(),
+            )
+        }
     }
 }
 
@@ -294,7 +305,18 @@ impl Rx {
         // Safe, because we're only taking the address of a register.
         let address = &unsafe { &*pac::AES::ptr() }.doutr as *const _ as u32;
 
-        dma::Transfer::peripheral_to_memory(dma, self, channel, buffer, address)
+        // Safe, because the traits bounds of this method guarantee that
+        // `buffer` can be written to.
+        unsafe {
+            dma::Transfer::new(
+                dma,
+                self,
+                channel,
+                buffer,
+                address,
+                dma::Direction::peripheral_to_memory(),
+            )
+        }
     }
 }
 

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -200,6 +200,8 @@ impl Tx {
     ///
     /// The AES peripheral works with 128-bit blocks, which means the buffer
     /// length must be a multiple of 4. Panics, if this is not the case.
+    ///
+    /// Panics, if the buffer is not aligned to a word boundary.
     pub fn write_all<Buffer, Channel>(self,
         dma:     &mut dma::Handle,
         buffer:  Pin<Buffer>,
@@ -273,6 +275,8 @@ impl Rx {
     ///
     /// The AES peripheral works with 128-bit blocks, which means the buffer
     /// length must be a multiple of 4. Panics, if this is not the case.
+    ///
+    /// Panics, if the buffer is not aligned to a word boundary.
     pub fn read_all<Buffer, Channel>(self,
         dma:     &mut dma::Handle,
         buffer:  Pin<Buffer>,

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -199,7 +199,7 @@ impl Tx {
     /// Panics, if the buffer length is larger than `u16::max_value()`.
     ///
     /// The AES peripheral works with 128-bit blocks, which means the buffer
-    /// length must be a multiple of 4. Panics, if this is not the case.
+    /// length must be a multiple of 16. Panics, if this is not the case.
     ///
     /// Panics, if the buffer is not aligned to a word boundary.
     pub fn write_all<Buffer, Channel>(self,
@@ -207,14 +207,14 @@ impl Tx {
         buffer:  Pin<Buffer>,
         channel: Channel,
     )
-        -> dma::Transfer<Self, Channel, Buffer, dma::Ready>
+        -> Transfer<Self, Channel, Buffer, dma::Ready>
         where
             Self:           dma::Target<Channel>,
             Buffer:         Deref + 'static,
-            Buffer::Target: AsSlice<Element=u32>,
+            Buffer::Target: AsSlice<Element=u8>,
             Channel:        dma::Channel,
     {
-        assert!(buffer.as_slice().len() % 4 == 0);
+        assert!(buffer.as_slice().len() % 16 == 0);
 
         // Safe, because we're only taking the address of a register.
         let address = &unsafe { &*pac::AES::ptr() }.dinr as *const _ as u32;
@@ -222,7 +222,7 @@ impl Tx {
         // Safe, because the traits bounds of this method guarantee that
         // `buffer` can be read from.
         unsafe {
-            dma::Transfer::new(
+            Transfer::new(
                 dma,
                 self,
                 channel,
@@ -285,7 +285,7 @@ impl Rx {
     /// Panics, if the buffer length is larger than `u16::max_value()`.
     ///
     /// The AES peripheral works with 128-bit blocks, which means the buffer
-    /// length must be a multiple of 4. Panics, if this is not the case.
+    /// length must be a multiple of 16. Panics, if this is not the case.
     ///
     /// Panics, if the buffer is not aligned to a word boundary.
     pub fn read_all<Buffer, Channel>(self,
@@ -293,14 +293,14 @@ impl Rx {
         buffer:  Pin<Buffer>,
         channel: Channel,
     )
-        -> dma::Transfer<Self, Channel, Buffer, dma::Ready>
+        -> Transfer<Self, Channel, Buffer, dma::Ready>
         where
             Self:           dma::Target<Channel>,
             Buffer:         DerefMut + 'static,
-            Buffer::Target: AsMutSlice<Element=u32>,
+            Buffer::Target: AsMutSlice<Element=u8>,
             Channel:        dma::Channel,
     {
-        assert!(buffer.as_slice().len() % 4 == 0);
+        assert!(buffer.as_slice().len() % 16 == 0);
 
         // Safe, because we're only taking the address of a register.
         let address = &unsafe { &*pac::AES::ptr() }.doutr as *const _ as u32;
@@ -308,7 +308,7 @@ impl Rx {
         // Safe, because the traits bounds of this method guarantee that
         // `buffer` can be written to.
         unsafe {
-            dma::Transfer::new(
+            Transfer::new(
                 dma,
                 self,
                 channel,
@@ -332,4 +332,124 @@ pub type Block = [u8; 16];
 pub enum Error {
     /// AES peripheral is busy
     Busy,
+}
+
+
+/// Wrapper around a [`dma::Transfer`].
+///
+/// This struct is required, because under the hood, the AES peripheral only
+/// supports 32-bit word DMA transfers, while the public API works with byte
+/// slices.
+pub struct Transfer<Target, Channel, Buffer, State> {
+    buffer: Pin<Buffer>,
+    inner:  dma::Transfer<Target, Channel, dma::PtrBuffer<u32>, State>,
+}
+
+impl<Target, Channel, Buffer> Transfer<Target, Channel, Buffer, dma::Ready>
+    where
+        Target:         dma::Target<Channel>,
+        Channel:        dma::Channel,
+        Buffer:         Deref + 'static,
+        Buffer::Target: AsSlice<Element=u8>,
+{
+    /// Create a new instance of `Transfer`
+    ///
+    /// # Safety
+    ///
+    /// If this is used to prepare a memory-to-peripheral transfer, the caller
+    /// must make sure that the buffer can be read from safely.
+    ///
+    /// If this is used to prepare a peripheral-to-memory transfer, the caller
+    /// must make sure that the buffer can be written to safely.
+    ///
+    /// The caller must guarantee that the buffer length is a multiple of 4.
+    unsafe fn new(
+        dma:     &mut dma::Handle,
+        target:  Target,
+        channel: Channel,
+        buffer:  Pin<Buffer>,
+        address: u32,
+        dir:     dma::Direction,
+    )
+        -> Self
+    {
+        let transfer = dma::Transfer::new(
+            dma,
+            target,
+            channel,
+            // The caller must guarantee that our length is a multiple of 4, so
+            // this should be fine.
+            Pin::new(dma::PtrBuffer {
+                ptr: buffer.as_slice().as_ptr() as *const u32,
+                len: buffer.as_slice().len() / 4,
+            }),
+            address,
+            dir,
+        );
+
+        Self {
+            buffer: buffer,
+            inner:  transfer,
+        }
+    }
+
+    /// Enables the provided interrupts
+    ///
+    /// This setting only affects this transfer. It doesn't affect transfer on
+    /// other channels, or subsequent transfers on the same channel.
+    pub fn enable_interrupts(&mut self, interrupts: dma::Interrupts) {
+        self.inner.enable_interrupts(interrupts)
+    }
+
+    /// Start the DMA transfer
+    ///
+    /// Consumes this instance of `Transfer` and returns a new one, with its
+    /// state changes to indicate that the transfer has been started.
+    pub fn start(self) -> Transfer<Target, Channel, Buffer, dma::Started> {
+        Transfer {
+            buffer: self.buffer,
+            inner:  self.inner.start(),
+        }
+    }
+}
+
+impl<Target, Channel, Buffer> Transfer<Target, Channel, Buffer, dma::Started>
+    where
+        Channel: dma::Channel,
+{
+    /// Indicates whether the transfer is still ongoing
+    pub fn is_active(&self) -> bool {
+        self.inner.is_active()
+    }
+
+    /// Waits for the transfer to finish and returns the owned resources
+    ///
+    /// This function will busily wait until the transfer is finished. If you
+    /// don't want this, please call this function only once you know that the
+    /// transfer has finished.
+    ///
+    /// This function will return immediately, if [`Transfer::is_active`]
+    /// returns `false`.
+    pub fn wait(self)
+        -> Result<
+            dma::TransferResources<Target, Channel, Buffer>,
+            (dma::TransferResources<Target, Channel, Buffer>, dma::Error)
+        >
+    {
+        let (res, err) = match self.inner.wait() {
+            Ok(res)         => (res, None),
+            Err((res, err)) => (res, Some(err)),
+        };
+
+        let res = dma::TransferResources {
+            target:  res.target,
+            channel: res.channel,
+            buffer:  self.buffer,
+        };
+
+        match err {
+            None      => Ok(res),
+            Some(err) => Err((res, err)),
+        }
+    }
 }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -109,7 +109,7 @@ impl<T, C, B> Transfer<T, C, B, Ready>
                 channel,
                 buffer,
                 address,
-                ccr1::DIRW::FROMMEMORY,
+                Direction::memory_to_peripheral(),
             )
         }
     }
@@ -136,7 +136,7 @@ impl<T, C, B> Transfer<T, C, B, Ready>
                 channel,
                 buffer,
                 address,
-                ccr1::DIRW::FROMPERIPHERAL,
+                Direction::peripheral_to_memory(),
             )
         }
     }
@@ -162,7 +162,7 @@ impl<T, C, B> Transfer<T, C, B, Ready>
         channel: C,
         buffer:  Pin<B>,
         address: u32,
-        dir:     ccr1::DIRW,
+        dir:     Direction,
     )
         -> Self
         where
@@ -177,7 +177,7 @@ impl<T, C, B> Transfer<T, C, B, Ready>
         channel.set_peripheral_address(handle, address);
         channel.set_memory_address(handle, buffer.as_slice().as_ptr() as u32);
         channel.set_transfer_len(handle, buffer.as_slice().len() as u16);
-        channel.configure::<Word>(handle, dir);
+        channel.configure::<Word>(handle, dir.0);
 
         Transfer {
             res: TransferResources {
@@ -257,6 +257,20 @@ pub struct TransferResources<T, C, B> {
 impl<T, C, B> fmt::Debug for TransferResources<T, C, B> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TransferResources {{ ... }}")
+    }
+}
+
+
+/// The direction of the DMA transfer
+pub(crate) struct Direction(ccr1::DIRW);
+
+impl Direction {
+    pub fn memory_to_peripheral() -> Self {
+        Self(ccr1::DIRW::FROMMEMORY)
+    }
+
+    pub fn peripheral_to_memory() -> Self {
+        Self(ccr1::DIRW::FROMPERIPHERAL)
     }
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -129,10 +129,18 @@ impl<T, C, B> Transfer<T, C, B, Ready>
         }
     }
 
+    /// Enables the provided interrupts
+    ///
+    /// This setting only affects this transfer. It doesn't affect transfer on
+    /// other channels, or subsequent transfers on the same channel.
     pub fn enable_interrupts(&mut self, interrupts: Interrupts) {
         self.res.channel.enable_interrupts(interrupts);
     }
 
+    /// Start the DMA transfer
+    ///
+    /// Consumes this instance of `Transfer` and returns a new one, with its
+    /// state changes to indicate that the transfer has been started.
     pub fn start(self) -> Transfer<T, C, B, Started> {
         compiler_fence(Ordering::SeqCst);
 
@@ -153,7 +161,7 @@ impl<T, C, B> Transfer<T, C, B, Started>
         self.res.channel.is_active()
     }
 
-    /// Waits for the transfer to finish and return owned resources
+    /// Waits for the transfer to finish and returns the owned resources
     ///
     /// This function will busily wait until the transfer is finished. If you
     /// don't want this, please call this function only once you know that the

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -469,6 +469,33 @@ impl<T, Word> Buffer<Word> for T
 }
 
 
+/// Can be used as a fallback [`Buffer`], if safer implementations can't be used
+pub(crate) struct PtrBuffer<Word> {
+    pub ptr: *const Word,
+    pub len: usize,
+}
+
+// Required to make in possible to put this in a `Pin`, in a way that satisfies
+// the requirements on `Transfer::new`.
+impl<Word> Deref for PtrBuffer<Word> {
+    type Target = Self;
+
+    fn deref(&self) -> &Self::Target {
+        self
+    }
+}
+
+impl<Word> Buffer<Word> for PtrBuffer<Word> {
+    fn as_ptr(&self) -> *const Word {
+        self.ptr
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+
 pub trait SupportedWordSize {
     fn size() -> ccr1::MSIZEW;
 }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -71,8 +71,8 @@ pub struct Handle {
 }
 
 
-pub struct Transfer<C, T, B, State> {
-    res:    TransferResources<C, T, B>,
+pub struct Transfer<T, C, B, State> {
+    res:    TransferResources<T, C, B>,
     _state: State,
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -15,6 +15,7 @@
 
 use core::{
     fmt,
+    mem,
     ops::{
         Deref,
         DerefMut,
@@ -153,6 +154,8 @@ impl<T, C, B> Transfer<T, C, B, Ready>
     /// # Panics
     ///
     /// Panics, if the length of the buffer is larger than `u16::max_value()`.
+    ///
+    /// Panics, if the buffer is not aligned to the word size.
     unsafe fn new<Word>(
         handle:  &mut Handle,
         target:  T,
@@ -168,6 +171,7 @@ impl<T, C, B> Transfer<T, C, B, Ready>
             Word:      SupportedWordSize,
     {
         assert!(buffer.as_slice().len() <= u16::max_value() as usize);
+        assert_eq!(buffer.as_ptr().align_offset(mem::size_of::<Word>()), 0);
 
         channel.select_target(handle, &target);
         channel.set_peripheral_address(handle, address);

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -16,10 +16,7 @@
 use core::{
     fmt,
     mem,
-    ops::{
-        Deref,
-        DerefMut,
-    },
+    ops::Deref,
     pin::Pin,
     sync::atomic::{
         compiler_fence,
@@ -27,10 +24,7 @@ use core::{
     }
 };
 
-use as_slice::{
-    AsMutSlice,
-    AsSlice,
-};
+use as_slice::AsSlice;
 
 use crate::{
     pac::{
@@ -87,60 +81,6 @@ impl<T, C, B> Transfer<T, C, B, Ready>
         T: Target<C>,
         C: Channel,
 {
-    pub(crate) fn memory_to_peripheral<Word>(
-        handle:  &mut Handle,
-        target:  T,
-        channel: C,
-        buffer:  Pin<B>,
-        address: u32,
-    )
-        -> Self
-        where
-            B:         Deref,
-            B::Target: AsSlice<Element=Word>,
-            Word:      SupportedWordSize,
-    {
-        // Safe, because the traits bounds of this method guarantee that
-        // `buffer` can be read from.
-        unsafe {
-            Self::new(
-                handle,
-                target,
-                channel,
-                buffer,
-                address,
-                Direction::memory_to_peripheral(),
-            )
-        }
-    }
-
-    pub(crate) fn peripheral_to_memory<Word>(
-        handle:  &mut Handle,
-        target:  T,
-        channel: C,
-        buffer:  Pin<B>,
-        address: u32,
-    )
-        -> Self
-        where
-            B:         DerefMut,
-            B::Target: AsMutSlice<Element=Word>,
-            Word:      SupportedWordSize,
-    {
-        // Safe, because the traits bounds of this method guarantee that
-        // `buffer` can be written to.
-        unsafe {
-            Self::new(
-                handle,
-                target,
-                channel,
-                buffer,
-                address,
-                Direction::peripheral_to_memory(),
-            )
-        }
-    }
-
     /// Internal constructor
     ///
     /// # Safety
@@ -156,7 +96,7 @@ impl<T, C, B> Transfer<T, C, B, Ready>
     /// Panics, if the length of the buffer is larger than `u16::max_value()`.
     ///
     /// Panics, if the buffer is not aligned to the word size.
-    unsafe fn new<Word>(
+    pub(crate) unsafe fn new<Word>(
         handle:  &mut Handle,
         target:  T,
         channel: C,


### PR DESCRIPTION
This pull request changes the AES API to work with `u8` buffers, instead of `u32` buffers, which should make it easier to use in most scenarios.

I've also snuck in a few commits that fix and improve some other things related to AES and DMA. It didn't seem worth it to create a separate pull request for those, especially since I've already got a bit a bit of a traffic jam going :-)

This pull request is based on #16. I recommend reviewing/merging that one first.

cc @lthiery 