### PR TITLE
Clean up PWM code, fix race conditions, improve STM32L0x2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,3 @@ required-features = ["rt"]
 [[example]]
 name = "adc_pwm"
 required-features = ["stm32l0x1"]
-
-[[example]]
-name = "pwm"
-required-features = ["stm32l0x1"]

--- a/examples/adc_pwm.rs
+++ b/examples/adc_pwm.rs
@@ -5,7 +5,7 @@
 extern crate panic_halt;
 
 use cortex_m_rt::entry;
-use stm32l0xx_hal::{pac, prelude::*, rcc::Config};
+use stm32l0xx_hal::{pac, prelude::*, pwm, rcc::Config};
 
 #[entry]
 fn main() -> ! {
@@ -19,9 +19,9 @@ fn main() -> ! {
     let gpioa = dp.GPIOA.split(&mut rcc);
 
     // Configure the timer as PWM on PA1.
-    let mut pwm = dp.TIM2.pwm(gpioa.pa1, 1.khz(), &mut rcc);
-    let max_duty = pwm.get_max_duty() / 4095;
-    pwm.enable();
+    let mut pwm = pwm::Timer::new(dp.TIM2, gpioa.pa1, 1.khz(), &mut rcc);
+    let max_duty = pwm.channels.get_max_duty() / 4095;
+    pwm.channels.enable();
 
     let mut adc = dp.ADC.constrain(&mut rcc);
 
@@ -31,6 +31,6 @@ fn main() -> ! {
     loop {
         // Set the PWM duty cycle from the value read on the ADC pin.
         let val: u16 = adc.read(&mut adc_pin).unwrap();
-        pwm.set_duty(max_duty * val);
+        pwm.channels.set_duty(max_duty * val);
     }
 }

--- a/examples/adc_pwm.rs
+++ b/examples/adc_pwm.rs
@@ -19,9 +19,10 @@ fn main() -> ! {
     let gpioa = dp.GPIOA.split(&mut rcc);
 
     // Configure the timer as PWM on PA1.
-    let mut pwm = pwm::Timer::new(dp.TIM2, gpioa.pa1, 1.khz(), &mut rcc);
-    let max_duty = pwm.channels.get_max_duty() / 4095;
-    pwm.channels.enable();
+    let pwm = pwm::Timer::new(dp.TIM2, 1.khz(), &mut rcc);
+    let mut pwm = pwm.channel2.assign(gpioa.pa1);
+    let max_duty = pwm.get_max_duty() / 4095;
+    pwm.enable();
 
     let mut adc = dp.ADC.constrain(&mut rcc);
 
@@ -31,6 +32,6 @@ fn main() -> ! {
     loop {
         // Set the PWM duty cycle from the value read on the ADC pin.
         let val: u16 = adc.read(&mut adc_pin).unwrap();
-        pwm.channels.set_duty(max_duty * val);
+        pwm.set_duty(max_duty * val);
     }
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -5,7 +5,6 @@
 
 extern crate panic_halt;
 
-use cortex_m::asm;
 use cortex_m_rt::entry;
 use stm32l0xx_hal::{pac, prelude::*, pwm, rcc::Config};
 
@@ -32,18 +31,17 @@ fn main() -> ! {
 
     pwm.channels.enable();
 
-    pwm.channels.set_duty(max);
-    delay.delay_ms(1000_u16);
-
-    pwm.channels.set_duty(max / 2);
-    delay.delay_ms(1000_u16);
-
-    pwm.channels.set_duty(max / 4);
-    delay.delay_ms(1000_u16);
-
-    pwm.channels.set_duty(max / 8);
-
     loop {
-        asm::nop();
+        pwm.channels.set_duty(max);
+        delay.delay_ms(500_u16);
+
+        pwm.channels.set_duty(max / 2);
+        delay.delay_ms(500_u16);
+
+        pwm.channels.set_duty(max / 4);
+        delay.delay_ms(500_u16);
+
+        pwm.channels.set_duty(max / 8);
+        delay.delay_ms(500_u16);
     }
 }

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -7,7 +7,7 @@ extern crate panic_halt;
 
 use cortex_m::asm;
 use cortex_m_rt::entry;
-use stm32l0xx_hal::{pac, prelude::*, rcc::Config};
+use stm32l0xx_hal::{pac, prelude::*, pwm, rcc::Config};
 
 #[entry]
 fn main() -> ! {
@@ -26,22 +26,22 @@ fn main() -> ! {
 
     // Configure TIM2 as PWM on PA1.
     let c2 = gpioa.pa1;
-    let mut pwm = dp.TIM2.pwm(c2, 10.khz(), &mut rcc);
+    let mut pwm = pwm::Timer::new(dp.TIM2, c2, 10.khz(), &mut rcc);
 
-    let max = pwm.get_max_duty();
+    let max = pwm.channels.get_max_duty();
 
-    pwm.enable();
+    pwm.channels.enable();
 
-    pwm.set_duty(max);
+    pwm.channels.set_duty(max);
     delay.delay_ms(1000_u16);
 
-    pwm.set_duty(max / 2);
+    pwm.channels.set_duty(max / 2);
     delay.delay_ms(1000_u16);
 
-    pwm.set_duty(max / 4);
+    pwm.channels.set_duty(max / 4);
     delay.delay_ms(1000_u16);
 
-    pwm.set_duty(max / 8);
+    pwm.channels.set_duty(max / 8);
 
     loop {
         asm::nop();

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -23,10 +23,15 @@ fn main() -> ! {
     // the RCC register.
     let gpioa = dp.GPIOA.split(&mut rcc);
 
-    // Configure TIM2 as PWM on PA1.
-    let c2 = gpioa.pa1;
+    // Initialize TIM2 for PWM
     let pwm = pwm::Timer::new(dp.TIM2, 10.khz(), &mut rcc);
-    let mut pwm = pwm.channel2.assign(c2);
+
+    #[cfg(feature = "stm32l0x1")]
+    let mut pwm = pwm.channel2.assign(gpioa.pa1);
+
+    // This is LD2 on ST's B-L072Z-LRWAN1 development board.
+    #[cfg(feature = "stm32l0x2")]
+    let mut pwm = pwm.channel1.assign(gpioa.pa5);
 
     let max = pwm.get_max_duty();
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -25,23 +25,24 @@ fn main() -> ! {
 
     // Configure TIM2 as PWM on PA1.
     let c2 = gpioa.pa1;
-    let mut pwm = pwm::Timer::new(dp.TIM2, c2, 10.khz(), &mut rcc);
+    let pwm = pwm::Timer::new(dp.TIM2, 10.khz(), &mut rcc);
+    let mut pwm = pwm.channel2.assign(c2);
 
-    let max = pwm.channels.get_max_duty();
+    let max = pwm.get_max_duty();
 
-    pwm.channels.enable();
+    pwm.enable();
 
     loop {
-        pwm.channels.set_duty(max);
+        pwm.set_duty(max);
         delay.delay_ms(500_u16);
 
-        pwm.channels.set_duty(max / 2);
+        pwm.set_duty(max / 2);
         delay.delay_ms(500_u16);
 
-        pwm.channels.set_duty(max / 4);
+        pwm.set_duty(max / 4);
         delay.delay_ms(500_u16);
 
-        pwm.channels.set_duty(max / 8);
+        pwm.set_duty(max / 8);
         delay.delay_ms(500_u16);
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -516,6 +516,26 @@ gpio!(GPIOC, gpioc, iopcen, PC, [
     PC15: (pc15, 15, Input<Floating>),
 ]);
 
+#[cfg(feature = "stm32l0x2")]
+gpio!(GPIOE, gpioe, iopeen, PE, [
+    PE0:  (pe0,  0,  Input<Floating>),
+    PE1:  (pe1,  1,  Input<Floating>),
+    PE2:  (pe2,  2,  Input<Floating>),
+    PE3:  (pe3,  3,  Input<Floating>),
+    PE4:  (pe4,  4,  Input<Floating>),
+    PE5:  (pe5,  5,  Input<Floating>),
+    PE6:  (pe6,  6,  Input<Floating>),
+    PE7:  (pe7,  7,  Input<Floating>),
+    PE8:  (pe8,  8,  Input<Floating>),
+    PE9:  (pe9,  9,  Input<Floating>),
+    PE10: (pe10, 10, Input<Floating>),
+    PE11: (pe11, 11, Input<Floating>),
+    PE12: (pe12, 12, Input<Floating>),
+    PE13: (pe13, 13, Input<Floating>),
+    PE14: (pe14, 14, Input<Floating>),
+    PE15: (pe15, 15, Input<Floating>),
+]);
+
 #[cfg(any(feature = "stm32l0x2"))]
 gpio!(GPIOH, gpioh, iophen, PH, [
     PH0: (ph0, 0, Input<Floating>),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,6 @@ pub use crate::delay::DelayExt as _stm32l0xx_hal_delay_DelayExt;
 pub use crate::exti::ExtiExt as _stm32l0xx_hal_exti_ExtiExt;
 pub use crate::gpio::GpioExt as _stm32l0xx_hal_gpio_GpioExt;
 pub use crate::i2c::I2cExt as _stm32l0xx_hal_i2c_I2cExt;
-pub use crate::pwm::PwmExt as _stm32l0xx_hal_pwm_PwmExt;
 pub use crate::rcc::RccExt as _stm32l0xx_hal_rcc_RccExt;
 pub use crate::serial::Serial1Ext as _stm32l0xx_hal_serial_Serial1Ext;
 pub use crate::serial::Serial2Ext as _stm32l0xx_hal_serial_Serial2Ext;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -226,27 +226,34 @@ pub trait Pin<I, C> {
 macro_rules! impl_pin {
     (
         $(
-            $name:ident,
-            $instance:ty,
-            $channel:ty,
-            $alternate_function:ident;
+            $instance:ty: (
+                $(
+                    $name:ident,
+                    $channel:ty,
+                    $alternate_function:ident;
+                )*
+            )
         )*
     ) => {
         $(
-            impl<State> Pin<$instance, $channel> for $name<State> {
-                fn setup(&self) {
-                    self.set_alt_mode(AltMode::$alternate_function);
+            $(
+                impl<State> Pin<$instance, $channel> for $name<State> {
+                    fn setup(&self) {
+                        self.set_alt_mode(AltMode::$alternate_function);
+                    }
                 }
-            }
+            )*
         )*
     }
 }
 
 impl_pin!(
-    PA0, TIM2, C1, AF2;
-    PA1, TIM2, C2, AF2;
-    PA2, TIM2, C3, AF2;
-    PA3, TIM2, C4, AF2;
+    TIM2: (
+        PA0, C1, AF2;
+        PA1, C2, AF2;
+        PA2, C3, AF2;
+        PA3, C4, AF2;
+    )
 );
 
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -153,7 +153,7 @@ impl<I, C> hal::PwmPin for Pwm<I, C>
 
 
 macro_rules! channels {
-    ($TIMX:ident, $af:expr, $c1:ty) => {
+    ($TIMX:ident, $af:expr, $c1:ty, $c2:ty, $c3:ty, $c4:ty) => {
         impl Pins<$TIMX> for $c1 {
             type Channels = Pwm<$TIMX, C1>;
 
@@ -161,9 +161,6 @@ macro_rules! channels {
                 self.set_alt_mode($af);
             }
         }
-    };
-    ($TIMX:ident, $af:expr, $c1:ty, $c2:ty, $c3:ty, $c4:ty) => {
-        channels!($TIMX, $af, $c1);
 
         impl Pins<$TIMX> for $c2 {
             type Channels = Pwm<$TIMX, C2>;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -13,6 +13,53 @@ use crate::rcc::Rcc;
 use crate::time::Hertz;
 use cast::{u16, u32};
 
+#[cfg(feature = "stm32l0x2")]
+use crate::gpio::{
+    gpioa::{
+        PA5,
+        PA15,
+    },
+    gpiob::{
+        PB3,
+        PB10,
+        PB11,
+    },
+};
+
+#[cfg(any(feature = "stm32l072", feature = "stm32l082"))]
+use crate::gpio::{
+    gpioa::{
+        PA6,
+        PA7,
+    },
+    gpiob::{
+        PB0,
+        PB1,
+        PB4,
+        PB5,
+    },
+};
+
+#[cfg(feature = "stm32l072")]
+use crate::gpio::{
+    gpioc::{
+        PC6,
+        PC7,
+        PC8,
+        PC9,
+    },
+    gpioe::{
+        PE3,
+        PE4,
+        PE5,
+        PE6,
+        PE9,
+        PE10,
+        PE11,
+        PE12,
+    },
+};
+
 
 pub struct Timer<I> {
     _instance: I,
@@ -253,6 +300,49 @@ impl_pin!(
         PA1, C2, AF2;
         PA2, C3, AF2;
         PA3, C4, AF2;
+    )
+);
+
+#[cfg(feature = "stm32l0x2")]
+impl_pin!(
+    TIM2: (
+        PA5,  C1, AF5;
+        PA15, C1, AF5;
+        PB3,  C2, AF2;
+        PB10, C3, AF2;
+        PB11, C4, AF2;
+    )
+);
+
+#[cfg(any(feature = "stm32l072", feature = "stm32l082"))]
+impl_pin!(
+    TIM3: (
+        PA6, C1, AF2;
+        PA7, C2, AF2;
+        PB0, C3, AF2;
+        PB1, C4, AF2;
+        PB4, C1, AF2;
+        PB5, C2, AF4;
+    )
+);
+
+#[cfg(feature = "stm32l072")]
+impl_pin!(
+    TIM2: (
+        PE9,  C1, AF0;
+        PE10, C2, AF0;
+        PE11, C3, AF0;
+        PE12, C4, AF0;
+    )
+    TIM3: (
+        PC6, C1, AF2;
+        PC7, C2, AF2;
+        PC8, C3, AF2;
+        PC9, C4, AF2;
+        PE3, C1, AF2;
+        PE4, C2, AF2;
+        PE5, C3, AF2;
+        PE6, C4, AF2;
     )
 );
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -158,9 +158,9 @@ pub trait Pins<TIM> {
 }
 
 
-pub struct Pwm<TIM, CHANNEL> {
-    _channel: PhantomData<CHANNEL>,
-    _tim: PhantomData<TIM>,
+pub struct Pwm<I, C> {
+    _channel: PhantomData<C>,
+    _tim: PhantomData<I>,
 }
 
 impl<I, C> hal::PwmPin for Pwm<I, C>

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -228,11 +228,7 @@ macro_rules! timers {
                 let psc = u16((ticks - 1) / (1 << 16)).unwrap();
                 let arr = u16(ticks / u32(psc + 1)).unwrap();
                 tim.psc.write(|w| unsafe { w.psc().bits(psc) });
-                #[allow(unused_unsafe)]
-                #[cfg(feature = "stm32l0x1")]
-                tim.arr.write(|w| unsafe { w.arr().bits(arr) });
-                #[cfg(feature = "stm32l0x2")]
-                tim.arr.write(|w| w.arr().bits(arr as u32));
+                tim.arr.write(|w| w.arr().bits(arr.into()));
                 tim.cr1.write(|w| w.cen().set_bit());
                 unsafe { mem::uninitialized() }
             }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -8,6 +8,7 @@ use crate::hal;
 use crate::pac::{
     tim2,
     TIM2,
+    TIM3,
 };
 use crate::rcc::Rcc;
 use crate::time::Hertz;
@@ -88,6 +89,7 @@ macro_rules! impl_instance {
 
 impl_instance!(
     TIM2, apb1enr, apb1rstr, tim2en, tim2rst, apb1_clk;
+    TIM3, apb1enr, apb1rstr, tim3en, tim3rst, apb1_clk;
 );
 
 


### PR DESCRIPTION
This is a big clean-up effort of the `pwm` module. It fixes the following problems:
- The module was a bit of a mess, with lots of duplicated code.
- Some of the `unsafe` access to timer registers was unsound, as it didn't take race conditions into account.
- The module was not flexible enough to support STM32L0x2 fully.

Overall, I believe that this new approach, with each channel being its own struct that can be configured separately, is a step in the right direction. In fact, I think we should consider using the same approach for the `timer` module, maybe even merge both modules. (I'm not sure if the hardware supports this, but if both modules were merged it could be possible to use one channel for PWM, another for something else, e.g. as a hardware trigger for ADC.)

cc @lthiery 