### PR TITLE
Add PWR API, support for wake-up via EXTI

### DIFF
--- a/examples/exti_wakeup.rs
+++ b/examples/exti_wakeup.rs
@@ -62,13 +62,15 @@ fn main() -> ! {
         interrupt::free(|_| {
             nvic.enable(Interrupt::EXTI2_3);
 
-            pwr.enter_stop_mode(
-                &mut scb,
-                &mut rcc,
-                pwr::StopModeConfig {
-                    ultra_low_power: true,
-                },
-            );
+            pwr
+                .stop_mode(
+                    &mut scb,
+                    &mut rcc,
+                    pwr::StopModeConfig {
+                        ultra_low_power: true,
+                    },
+                )
+                .enter();
 
             exti.clear_irq(button.i);
             NVIC::unpend(Interrupt::EXTI2_3);

--- a/examples/exti_wakeup.rs
+++ b/examples/exti_wakeup.rs
@@ -17,7 +17,10 @@ use stm32l0xx_hal::{
         self,
         Interrupt,
     },
-    pwr::PWR,
+    pwr::{
+        self,
+        PWR,
+    },
     rcc::Config,
 };
 
@@ -59,7 +62,13 @@ fn main() -> ! {
         interrupt::free(|_| {
             nvic.enable(Interrupt::EXTI2_3);
 
-            pwr.enter_sleep_mode(&mut scb);
+            pwr.enter_stop_mode(
+                &mut scb,
+                &mut rcc,
+                pwr::StopModeConfig {
+                    ultra_low_power: true,
+                },
+            );
 
             exti.clear_irq(button.i);
             NVIC::unpend(Interrupt::EXTI2_3);

--- a/examples/exti_wakeup.rs
+++ b/examples/exti_wakeup.rs
@@ -26,7 +26,7 @@ fn main() -> ! {
     let mut rcc   = dp.RCC.freeze(Config::hsi16());
     let     gpiob = dp.GPIOB.split(&mut rcc);
     let mut exti  = dp.EXTI;
-    let mut pwr   = PWR::new(dp.PWR);
+    let mut pwr   = PWR::new(dp.PWR, &mut rcc);
     let mut delay = cp.SYST.delay(rcc.clocks);
     let mut nvic  = cp.NVIC;
     let mut scb   = cp.SCB;

--- a/examples/exti_wakeup.rs
+++ b/examples/exti_wakeup.rs
@@ -6,7 +6,6 @@ extern crate panic_halt;
 
 
 use cortex_m::{
-    asm,
     interrupt,
     peripheral::NVIC,
 };
@@ -18,6 +17,7 @@ use stm32l0xx_hal::{
         self,
         Interrupt,
     },
+    pwr::PWR,
     rcc::Config,
 };
 
@@ -30,8 +30,10 @@ fn main() -> ! {
     let mut rcc   = dp.RCC.freeze(Config::hsi16());
     let     gpiob = dp.GPIOB.split(&mut rcc);
     let     exti  = dp.EXTI;
+    let mut pwr   = PWR::new(dp.PWR);
     let mut delay = cp.SYST.delay(rcc.clocks);
     let mut nvic  = cp.NVIC;
+    let mut scb   = cp.SCB;
 
     // Those are the user button and blue LED on the B-L072Z-LRWAN1 Discovery
     // board.
@@ -57,7 +59,7 @@ fn main() -> ! {
         interrupt::free(|_| {
             nvic.enable(Interrupt::EXTI2_3);
 
-            asm::wfi();
+            pwr.enter_sleep_mode(&mut scb);
 
             exti.clear_irq(button.i);
             NVIC::unpend(Interrupt::EXTI2_3);

--- a/examples/exti_wakeup.rs
+++ b/examples/exti_wakeup.rs
@@ -1,0 +1,71 @@
+#![no_main]
+#![no_std]
+
+
+extern crate panic_halt;
+
+
+use cortex_m::{
+    asm,
+    interrupt,
+    peripheral::NVIC,
+};
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    prelude::*,
+    exti,
+    pac::{
+        self,
+        Interrupt,
+    },
+    rcc::Config,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let cp = pac::CorePeripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcc   = dp.RCC.freeze(Config::hsi16());
+    let     gpiob = dp.GPIOB.split(&mut rcc);
+    let     exti  = dp.EXTI;
+    let mut delay = cp.SYST.delay(rcc.clocks);
+    let mut nvic  = cp.NVIC;
+
+    // Those are the user button and blue LED on the B-L072Z-LRWAN1 Discovery
+    // board.
+    let     button = gpiob.pb2.into_floating_input();
+    let mut led    = gpiob.pb6.into_push_pull_output();
+
+    #[cfg(feature = "stm32l0x1")]
+    let mut syscfg = dp.SYSCFG;
+    #[cfg(feature = "stm32l0x2")]
+    let mut syscfg = dp.SYSCFG_COMP;
+
+    exti.listen(
+        &mut rcc,
+        &mut syscfg,
+        button.port,
+        button.i,
+        exti::TriggerEdge::Falling,
+    );
+
+    loop {
+        // This construct allows us to wait for the interrupt without having to
+        // define an interrupt handler.
+        interrupt::free(|_| {
+            nvic.enable(Interrupt::EXTI2_3);
+
+            asm::wfi();
+
+            exti.clear_irq(button.i);
+            NVIC::unpend(Interrupt::EXTI2_3);
+            nvic.disable(Interrupt::EXTI2_3);
+        });
+
+        led.set_high().unwrap();
+        delay.delay_ms(100u32);
+        led.set_low().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod gpio;
 pub mod i2c;
 pub mod prelude;
 pub mod pwm;
+pub mod pwr;
 pub mod rcc;
 pub mod serial;
 pub mod spi;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,6 +14,7 @@ pub use crate::{
     exti::ExtiExt as _,
     gpio::GpioExt as _,
     i2c::I2cExt as _,
+    pwr::PowerMode as _,
     rcc::RccExt as _,
     serial::{
         Serial1Ext as _,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,20 +1,20 @@
 pub use embedded_hal::digital::v2::*;
 pub use embedded_hal::prelude::*;
 
-pub use crate::hal::adc::OneShot as _hal_adc_OneShot;
-pub use crate::hal::watchdog::Watchdog as _hal_watchdog_Watchdog;
-pub use crate::hal::watchdog::WatchdogEnable as _hal_watchdog_WatchdogEnable;
+pub use crate::hal::adc::OneShot as _;
+pub use crate::hal::watchdog::Watchdog as _;
+pub use crate::hal::watchdog::WatchdogEnable as _;
 
-pub use crate::adc::AdcExt as _stm32l0xx_hal_analog_AdcExt;
-pub use crate::delay::DelayExt as _stm32l0xx_hal_delay_DelayExt;
-pub use crate::exti::ExtiExt as _stm32l0xx_hal_exti_ExtiExt;
-pub use crate::gpio::GpioExt as _stm32l0xx_hal_gpio_GpioExt;
-pub use crate::i2c::I2cExt as _stm32l0xx_hal_i2c_I2cExt;
-pub use crate::rcc::RccExt as _stm32l0xx_hal_rcc_RccExt;
-pub use crate::serial::Serial1Ext as _stm32l0xx_hal_serial_Serial1Ext;
-pub use crate::serial::Serial2Ext as _stm32l0xx_hal_serial_Serial2Ext;
-pub use crate::spi::SpiExt as _stm32l0xx_hal_spi_SpiExt;
-pub use crate::time::U32Ext as _stm32l0xx_hal_time_U32Ext;
-pub use crate::timer::TimerExt as _stm32l0xx_hal_timer_TimerExt;
-pub use crate::watchdog::IndependedWatchdogExt as _stm32l0xx_hal_watchdog_IndependedWatchdogExt;
-pub use crate::watchdog::WindowWatchdogExt as _stm32l0xx_hal_watchdog_WindowWatchdogExt;
+pub use crate::adc::AdcExt as _;
+pub use crate::delay::DelayExt as _;
+pub use crate::exti::ExtiExt as _;
+pub use crate::gpio::GpioExt as _;
+pub use crate::i2c::I2cExt as _;
+pub use crate::rcc::RccExt as _;
+pub use crate::serial::Serial1Ext as _;
+pub use crate::serial::Serial2Ext as _;
+pub use crate::spi::SpiExt as _;
+pub use crate::time::U32Ext as _;
+pub use crate::timer::TimerExt as _;
+pub use crate::watchdog::IndependedWatchdogExt as _;
+pub use crate::watchdog::WindowWatchdogExt as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,20 +1,29 @@
-pub use embedded_hal::digital::v2::*;
-pub use embedded_hal::prelude::*;
+pub use embedded_hal::{
+    prelude::*,
+    digital::v2::*,
+    adc::OneShot as _,
+    watchdog::{
+        Watchdog as _,
+        WatchdogEnable as _,
+    },
+};
 
-pub use crate::hal::adc::OneShot as _;
-pub use crate::hal::watchdog::Watchdog as _;
-pub use crate::hal::watchdog::WatchdogEnable as _;
-
-pub use crate::adc::AdcExt as _;
-pub use crate::delay::DelayExt as _;
-pub use crate::exti::ExtiExt as _;
-pub use crate::gpio::GpioExt as _;
-pub use crate::i2c::I2cExt as _;
-pub use crate::rcc::RccExt as _;
-pub use crate::serial::Serial1Ext as _;
-pub use crate::serial::Serial2Ext as _;
-pub use crate::spi::SpiExt as _;
-pub use crate::time::U32Ext as _;
-pub use crate::timer::TimerExt as _;
-pub use crate::watchdog::IndependedWatchdogExt as _;
-pub use crate::watchdog::WindowWatchdogExt as _;
+pub use crate::{
+    adc::AdcExt as _,
+    delay::DelayExt as _,
+    exti::ExtiExt as _,
+    gpio::GpioExt as _,
+    i2c::I2cExt as _,
+    rcc::RccExt as _,
+    serial::{
+        Serial1Ext as _,
+        Serial2Ext as _,
+    },
+    spi::SpiExt as _,
+    time::U32Ext as _,
+    timer::TimerExt as _,
+    watchdog::{
+        IndependedWatchdogExt as _,
+        WindowWatchdogExt as _,
+    },
+};

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -23,7 +23,14 @@ pub struct PWR(pac::PWR);
 
 impl PWR {
     /// Create an instance of the PWR API
-    pub fn new(pwr: pac::PWR) -> Self {
+    pub fn new(pwr: pac::PWR, rcc: &mut Rcc) -> Self {
+        // Reset peripheral
+        rcc.rb.apb1rstr.modify(|_, w| w.pwrrst().set_bit());
+        rcc.rb.apb1rstr.modify(|_, w| w.pwrrst().clear_bit());
+
+        // Enable peripheral clock
+        rcc.rb.apb1enr.modify(|_, w| w.pwren().set_bit());
+
         Self(pwr)
     }
 

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -1,0 +1,33 @@
+//! Interface to the Power control (PWR) peripheral
+//!
+//! See STM32L0x2 reference manual, chapter 6.
+
+
+use cortex_m::{
+    asm,
+    peripheral::SCB,
+};
+
+use crate::pac;
+
+
+/// Entry point to the PWR API
+pub struct PWR(pac::PWR);
+
+impl PWR {
+    /// Create an instance of the PWR API
+    pub fn new(pwr: pac::PWR) -> Self {
+        Self(pwr)
+    }
+
+    /// Enter Sleep mode
+    ///
+    /// This method will block until something the microcontroller up again.
+    /// Please make sure to configure an interrupt, or this could block forever.
+    ///
+    /// Please note that this method may change the SCB configuration.
+    pub fn enter_sleep_mode(&mut self, scb: &mut SCB) {
+        scb.clear_sleepdeep();
+        asm::wfi();
+    }
+}

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -8,7 +8,14 @@ use cortex_m::{
     peripheral::SCB,
 };
 
-use crate::pac;
+use crate::{
+    pac,
+    rcc::{
+        ClockSrc,
+        PLLSource,
+        Rcc,
+    },
+};
 
 
 /// Entry point to the PWR API
@@ -30,4 +37,99 @@ impl PWR {
         scb.clear_sleepdeep();
         asm::wfi();
     }
+
+    /// Enter Stop mode
+    ///
+    /// This method will block until something the microcontroller up again.
+    /// Please make sure to configure an interrupt, or this could block forever.
+    ///
+    /// This method will always disable the internal voltage regulator during
+    /// Stop mode.
+    ///
+    /// Please note that this method may change the SCB configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if the external clock is selected as clock source. In principle,
+    /// it is possible to enter Stop mode with the external clock enabled,
+    /// although that might require special handling. This is explained in the
+    /// STM32L0x2 Reference Manual, section 6.3.9.
+    pub fn enter_stop_mode(&mut self,
+        scb:    &mut SCB,
+        rcc:    &mut Rcc,
+        config: StopModeConfig,
+    ) {
+        scb.set_sleepdeep();
+
+        // Restore current clock source after waking up from Stop mode.
+        rcc.rb.cfgr.modify(|_, w|
+            match rcc.clocks.source() {
+                ClockSrc::MSI(_) =>
+                    // Use MSI as clock source after wake-up
+                    w.stopwuck().clear_bit(),
+                ClockSrc::HSI16 | ClockSrc::PLL(PLLSource::HSI16, _, _) =>
+                    // Use HSI16 as clock source after wake-up
+                    w.stopwuck().set_bit(),
+                _ =>
+                    // External clock selected
+                    //
+                    // Unfortunately handling the external clock is not as
+                    // straight-forward as handling MSI or HSI16. We need to
+                    // know whether the external clock is going to be shut down
+                    // during Stop mode. If it is, we need to either shut it
+                    // down before entering Stop mode, or enable the clock
+                    // security system (CSS) and handle any failures using it.
+                    // This is explained in sectoin 6.3.9 of the STM32L0x2
+                    // Reference Manual.
+                    //
+                    // In principle, we could ask the user (through
+                    // `StopModeConfig`), whether to shut down the external
+                    // clock then restore is after we wake up again. However, to
+                    // do this we'd either need to refactor the `rcc` module,
+                    // making it more flexible so we can reuse the relevant code
+                    // here, or duplicate that code. I (hannobraun) am not to
+                    // keen on either right now, given that I don't have a test
+                    // setup with an external clock source at hand.
+                    //
+                    // One might ask why we need to restore the configuration at
+                    // all after waking up, but that's absolutely required. This
+                    // HAL's architecture assumes that the clocks are configured
+                    // once, then never changed again. If we left Stop mode with
+                    // a different clock frequency than we entered it with, a
+                    // lot of peripheral would stop working correctly.
+                    //
+                    // For now, I've decided to just not support this case and
+                    // panic, which is also documented in this method's doc
+                    // comment.
+                    panic!("External clock not supported for Stop mode"),
+            }
+        );
+
+        self.0.cr.modify(|_, w|
+            w
+                // Ultra-low-power mode
+                .ulp().bit(config.ultra_low_power)
+                // Enter Stop mode
+                .pdds().stop_mode()
+                // Disable internal voltage regulator
+                .lpds().set_bit()
+        );
+        asm::wfi();
+    }
+}
+
+
+/// Configuration for entering Stop mode
+///
+/// Used by [`PWR::enter_stop_mode`].
+pub struct StopModeConfig {
+    /// Disable additional hardware when entering Stop mode
+    ///
+    /// When set to `true`, the following hardware will be disabled:
+    ///
+    /// - Internal voltage reference (Vrefint)
+    /// - Brown out reset (BOR)
+    /// - Programmable voltage detector (PVD)
+    /// - Internal temperature sensor
+    pub ultra_low_power: bool,
 }

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -2,6 +2,7 @@ use crate::pac::RCC;
 use crate::time::{Hertz, U32Ext};
 
 /// System clock mux source
+#[derive(Clone, Copy)]
 pub enum ClockSrc {
     MSI(MSIRange),
     PLL(PLLSource, PLLMul, PLLDiv),
@@ -334,6 +335,7 @@ impl RccExt for RCC {
         };
 
         let clocks = Clocks {
+            source: cfgr.mux,
             sys_clk: sys_clk.hz(),
             ahb_clk: ahb_freq.hz(),
             apb1_clk: apb1_freq.hz(),
@@ -351,6 +353,7 @@ impl RccExt for RCC {
 /// The existence of this value indicates that the clock configuration can no longer be changed
 #[derive(Clone, Copy)]
 pub struct Clocks {
+    source: ClockSrc,
     sys_clk: Hertz,
     ahb_clk: Hertz,
     apb1_clk: Hertz,
@@ -360,6 +363,11 @@ pub struct Clocks {
 }
 
 impl Clocks {
+    /// Returns the clock source
+    pub fn source(&self) -> &ClockSrc {
+        &self.source
+    }
+
     /// Returns the system (core) frequency
     pub fn sys_clk(&self) -> Hertz {
         self.sys_clk


### PR DESCRIPTION
Add a PRW API with support for Sleep and Stop modes, as well as a method that goes to sleep and waits for an EXTI interrupt. I also snuck in some clean-up of the `prelude` module, while I was in there.

cc @lthiery 