### PR TITLE
Add support for wakeup via RTC wakeup timer

### DIFF
--- a/examples/rtc_wakeup.rs
+++ b/examples/rtc_wakeup.rs
@@ -1,0 +1,101 @@
+#![no_main]
+#![no_std]
+
+
+extern crate panic_halt;
+
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    exti,
+    gpio,
+    prelude::*,
+    pac,
+    pwr::{
+        self,
+        PWR,
+    },
+    rcc,
+    rtc::{
+        self,
+        Instant,
+        RTC,
+    },
+};
+
+
+#[entry]
+fn main() -> ! {
+    let cp = pac::CorePeripherals::take().unwrap();
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcc   = dp.RCC.freeze(rcc::Config::hsi16());
+    let mut delay = cp.SYST.delay(rcc.clocks);
+    let mut nvic  = cp.NVIC;
+    let mut scb   = cp.SCB;
+    let mut exti  = dp.EXTI;
+    let     gpiob = dp.GPIOB.split(&mut rcc);
+    let mut pwr   = PWR::new(dp.PWR, &mut rcc);
+
+    #[cfg(feature = "stm32l0x1")]
+    let mut syscfg = dp.SYSCFG;
+    #[cfg(feature = "stm32l0x2")]
+    let mut syscfg = dp.SYSCFG_COMP;
+
+    let     button = gpiob.pb5.into_floating_input();
+    let mut led    = gpiob.pb12.into_push_pull_output();
+
+    // Disable LED
+    led.set_high().unwrap();
+
+    let instant = Instant::new()
+        .set_year(19)
+        .set_month(8)
+        .set_day(12)
+        .set_hour(12)
+        .set_minute(55)
+        .set_second(0);
+
+    let mut rtc = RTC::new(
+        dp.RTC,
+        &mut rcc,
+        &mut pwr,
+        instant,
+    );
+
+    let exti_line = 20; // RTC wakeup timer
+
+    rtc.enable_interrupts(rtc::Interrupts {
+        wakeup_timer: true,
+        .. rtc::Interrupts::default()
+    });
+    exti.listen(
+        &mut rcc,
+        &mut syscfg,
+        gpio::Port::PA, // argument ignored; next argument is not a GPIO line
+        exti_line,
+        exti::TriggerEdge::Rising,
+    );
+
+    loop {
+        led.set_low().unwrap();
+        delay.delay_ms(100u32);
+        led.set_high().unwrap();
+
+        while button.is_low().unwrap() {}
+
+        rtc.wakeup_timer().start(1u32);
+
+        exti.wait_for_irq(
+            exti_line,
+            pwr.stop_mode(
+                &mut scb,
+                &mut rcc,
+                pwr::StopModeConfig {
+                    ultra_low_power: true,
+                },
+            ),
+            &mut nvic,
+        );
+    }
+}

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -60,10 +60,8 @@ impl ExtiExt for EXTI {
         line: u8,
         edge: TriggerEdge,
     ) {
-        #[cfg(feature = "stm32l0x1")]
-        assert!(line < 24);
-        #[cfg(feature = "stm32l0x2")]
-        assert!(line < 15);
+        assert!(line <= 22);
+        assert_ne!(line, 18);
 
         // ensure that the SYSCFG peripheral is powered on
         // SYSCFG is necessary to change which PORT is routed to EXTIn
@@ -147,14 +145,18 @@ impl ExtiExt for EXTI {
     }
 
     fn unlisten(&self, line: u8) {
-        assert!(line < 24);
+        assert!(line <= 22);
+        assert_ne!(line, 18);
+
         bb::clear(&self.rtsr, line);
         bb::clear(&self.ftsr, line);
         bb::clear(&self.imr, line);
     }
 
     fn pend_interrupt(&self, line: u8) {
-        assert!(line < 24);
+        assert!(line <= 22);
+        assert_ne!(line, 18);
+
         bb::set(&self.swier, line);
     }
 
@@ -163,7 +165,9 @@ impl ExtiExt for EXTI {
     }
 
     fn clear_irq(&self, line: u8) {
-        assert!(line < 24);
+        assert!(line <= 22);
+        assert_ne!(line, 18);
+
         self.pr.modify(|_, w| unsafe { w.bits(0b1 << line) });
     }
 

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -186,6 +186,7 @@ impl ExtiExt for EXTI {
             0 ..=  1 => pac::Interrupt::EXTI0_1,
             2 ..=  3 => pac::Interrupt::EXTI2_3,
             4 ..= 15 => pac::Interrupt::EXTI4_15,
+            20       => pac::Interrupt::RTC,
             line     => panic!("Line {} not supported", line),
         };
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -229,6 +229,34 @@ impl RTC {
             second:  tr.st().bits() * 10 +  tr.su().bits(),
         }
     }
+
+    /// Enable interrupts
+    ///
+    /// The interrupts set to `true` in `interrupts` will be enabled. Those set
+    /// to false will not be modified.
+    pub fn enable_interrupts(&mut self, interrupts: Interrupts) {
+        self.rtc.cr.modify(|_, w| {
+            if interrupts.timestamp { w.tsie().set_bit(); }
+            if interrupts.wakeup_timer { w.wutie().set_bit(); }
+            if interrupts.alarm_b { w.alrbie().set_bit(); }
+            if interrupts.alarm_a { w.alraie().set_bit(); }
+            w
+        });
+    }
+
+    /// Disable interrupts
+    ///
+    /// The interrupts set to `true` in `interrupts` will be disabled. Those set
+    /// to false will not be modified.
+    pub fn disable_interrupts(&mut self, interrupts: Interrupts) {
+        self.rtc.cr.modify(|_, w| {
+            if interrupts.timestamp { w.tsie().clear_bit(); }
+            if interrupts.wakeup_timer { w.wutie().clear_bit(); }
+            if interrupts.alarm_b { w.alrbie().clear_bit(); }
+            if interrupts.alarm_a { w.alraie().clear_bit(); }
+            w
+        });
+    }
 }
 
 
@@ -359,5 +387,24 @@ impl Instant {
 
     pub fn second(&self) -> u8 {
         self.second
+    }
+}
+
+
+pub struct Interrupts {
+    pub timestamp:    bool,
+    pub wakeup_timer: bool,
+    pub alarm_a:      bool,
+    pub alarm_b:      bool,
+}
+
+impl Default for Interrupts {
+    fn default() -> Self {
+        Self {
+            timestamp:    false,
+            wakeup_timer: false,
+            alarm_a:      false,
+            alarm_b:      false,
+        }
     }
 }

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -100,6 +100,7 @@ impl RTC {
         rtc
     }
 
+    /// Sets the date/time
     pub fn set(&mut self, instant: Instant) {
         // Disable write protection.
         // This is safe, as we're only writin the correct and expected values.
@@ -181,6 +182,7 @@ impl RTC {
         self.rtc.isr.modify(|_, w| w.init().clear_bit());
     }
 
+    /// Returns the current date/time
     pub fn now(&mut self) -> Instant {
         // We need to wait until the RSF bit is set, for a multitude of reasons:
         // - In case the last read was within two cycles of RTCCLK. Not sure why

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -129,8 +129,8 @@ impl RTC {
             // Safe, because we're only writing valid values to the fields.
             unsafe {
                 w
-                    .prediv_a().bits(64)
-                    .prediv_s().bits(512)
+                    .prediv_a().bits(0x7f)
+                    .prediv_s().bits(0xff)
             }
         );
 

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -118,9 +118,7 @@ impl RTC {
         // Configure RTC. For now, the default values are all fine.
         self.rtc.cr.reset();
 
-        // Configuring the prescaler to generate a 1 Hz clock for the calendar.
-        // I think this may be necessary for the calendar to function correctly,
-        // but the documentation (section 26.4.7) is not super clear about that.
+        // Configure the prescaler to generate a 1 Hz clock for the calendar.
         //
         // ATTENTION:
         // This assumes the RTC clock frequency is 32768 Hz. If this assumption


### PR DESCRIPTION
As the title says, this pull requests adds support for waking up from low-power modes using the RTC wakeup timer. In addition it adds some fixes of and improvements upon my previous RTC PR.

It also makes some changes to the EXTI API that are required to support the RTC wakeup timer. The new capabilities are basically duct-taped on top of the old ones, which leads to some weird issues (like the `listen`'s `port` argument being ignored when it doesn't make sense).

This is far from the ideal approach, and I believe there's a possible EXTI API that is much more type-safe and has more natural support for non-GPIO interrupts. However, I don't have the time to figure that out right now.

I plan to go back and take a look at an EXTI redesign after I've completed some more urgent task. Probably late September or October.

cc @lthiery 