### PR TITLE
Bump version (0.3.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "0BSD"
 name = "stm32l0xx-hal"
 readme = "README.md"
 repository = "https://github.com/stm32-rs/stm32l0xx-hal"
-version = "0.2.0"
+version = "0.3.0"
 
 [package.metadata.docs.rs]
 features = ["stm32l0x1", "stm32l0x2", "rt"]


### PR DESCRIPTION
Blocked on https://github.com/stm32-rs/stm32l0xx-hal/pull/30
See also: https://github.com/stm32-rs/stm32l0xx-hal/pull/32