### PR TITLE
Add LPUART1, USART4, USART5 support for stm32l0x3

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -517,6 +517,26 @@ gpio!(GPIOC, gpioc, iopcen, PC, [
 ]);
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+gpio!(GPIOD, gpiod, iopcen, PC, [
+    PD0: (pd0, 0, Input<Floating>),
+    PD1: (pd1, 1, Input<Floating>),
+    PD2: (pd2, 2, Input<Floating>),
+    PD3: (pd3, 3, Input<Floating>),
+    PD4: (pd4, 4, Input<Floating>),
+    PD5: (pd5, 5, Input<Floating>),
+    PD6: (pd6, 6, Input<Floating>),
+    PD7: (pd7, 7, Input<Floating>),
+    PD8: (pd8, 8, Input<Floating>),
+    PD9: (pd9, 9, Input<Floating>),
+    PD10: (pd10, 10, Input<Floating>),
+    PD11: (pd11, 11, Input<Floating>),
+    PD12: (pd12, 12, Input<Floating>),
+    PD13: (pd13, 13, Input<Floating>),
+    PD14: (pd14, 14, Input<Floating>),
+    PD15: (pd15, 15, Input<Floating>),
+]);
+
+#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 gpio!(GPIOE, gpioe, iopeen, PE, [
     PE0:  (pe0,  0,  Input<Floating>),
     PE1:  (pe1,  1,  Input<Floating>),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -4,7 +4,7 @@ use core::ops::Deref;
 
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 
-use crate::gpio::gpioa::{PA10, PA13, PA9};
+use crate::gpio::gpioa::{PA10, PA9};
 use crate::gpio::gpiob::{PB6, PB7};
 use crate::gpio::{AltMode, OpenDrain, Output};
 use crate::pac::{i2c1::RegisterBlock, I2C1};
@@ -13,13 +13,13 @@ use crate::time::Hertz;
 use cast::u8;
 
 #[cfg(feature = "stm32l0x1")]
-use crate::gpio::gpioa::PA4;
+use crate::gpio::gpioa::{PA13, PA4};
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 use crate::{
     gpio::{
         gpioa::PA8,
-        gpiob::{PB11, PB14, PB4, PB8, PB9},
+        gpiob::{PB10, PB11, PB13, PB14, PB4, PB8, PB9},
         gpioc::{PC0, PC1},
     },
     pac::{I2C2, I2C3},
@@ -364,8 +364,8 @@ i2c!(
         (PB14<Output<OpenDrain>>, AltMode::AF5),
     ],
     scl: [
-        (PA10<Output<OpenDrain>>, AltMode::AF6),
-        (PA13<Output<OpenDrain>>, AltMode::AF5),
+        (PB10<Output<OpenDrain>>, AltMode::AF6),
+        (PB13<Output<OpenDrain>>, AltMode::AF5),
     ],
 );
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -25,8 +25,11 @@ use as_slice::{AsMutSlice, AsSlice};
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 pub use crate::{
     dma,
-    gpio::gpiob::{PB6, PB7},
-    pac::USART1,
+    gpio::gpiob::*,
+    gpio::gpioc::*,
+    gpio::gpiod::*,
+    gpio::gpioe::*, 
+    pac::{LPUART1, USART1, USART4, USART5},
 };
 
 /// Serial error
@@ -163,10 +166,17 @@ impl_pins!(
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 impl_pins!(
+    LPUART1, PA2, PA3,  AF6;
     USART1, PA9,  PA10, AF4;
     USART1, PB6,  PB7,  AF0;
     USART2, PA2,  PA3,  AF4;
     USART2, PA14, PA15, AF4;
+    USART2, PD5,  PD6,  AF0;
+    USART4, PA0,  PA1,  AF6;
+    USART4, PC10, PC11, AF6;
+    USART4, PE8,  PE9,  AF6;
+    USART5, PB3,  PB4,  AF6;
+    USART5, PE10, PE11, AF6; 
 );
 
 /// Serial abstraction
@@ -514,8 +524,11 @@ usart! {
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 usart! {
+    LPUART1: (lpuart1, apb1enr, lpuart1en, apb1_clk, Serial1LpExt),
     USART1: (usart1, apb2enr, usart1en, apb1_clk, Serial1Ext),
     USART2: (usart2, apb1enr, usart2en, apb1_clk, Serial2Ext),
+    USART4: (usart4, apb1enr, usart4en, apb1_clk, Serial4Ext),
+    USART5: (usart5, apb1enr, usart5en, apb1_clk, Serial5Ext), 
 }
 
 impl<USART> fmt::Write for Serial<USART>


### PR DESCRIPTION
Add all possible pin assignments. 
Only following assignments tested with real HW:
LPUART1, PA2, PA3,  AF6;
USART4, PA0,  PA1,  AF6;