### PR TITLE
Make RTFM a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ embedded-hal = { version = "0.2.3", features = ["unproven"] }
 cortex-m = {version = "0.6.0", features = ["const-fn"] }
 cortex-m-rt = "0.6.8"
 cortex-m-semihosting = "0.3.2"
-cortex-m-rtfm = "0.4.3"
 void = { version = "1.0.2", default-features = false }
 cast = { version = "0.2.2", default-features = false }
 nb = "0.1.2"
@@ -45,6 +44,7 @@ aligned = "0.3.1"
 heapless = "0.5.0"
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.1"
+cortex-m-rtfm = "0.4.3"
 
 [features]
 # Miscellaneaous features


### PR DESCRIPTION
It isn't needed as a normal dependency, and pulls in an old cortex-m version (0.5.x).