### PR TITLE
Added write_some and read_some methods to I2c and UART peripherals

### DIFF
--- a/src/aes.rs
+++ b/src/aes.rs
@@ -595,6 +595,8 @@ impl<Target, Channel, Buffer> Transfer<Target, Channel, Buffer, dma::Ready>
     )
         -> Self
     {
+        let num_words = buffer.as_slice().len() / 4;
+
         let transfer = dma::Transfer::new(
             dma,
             target,
@@ -603,8 +605,9 @@ impl<Target, Channel, Buffer> Transfer<Target, Channel, Buffer, dma::Ready>
             // this should be fine.
             Pin::new(dma::PtrBuffer {
                 ptr: buffer.as_slice().as_ptr() as *const u32,
-                len: buffer.as_slice().len() / 4,
+                len: num_words
             }),
+            num_words,
             address,
             priority,
             dir,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -19,6 +19,8 @@ use crate::hal::blocking::i2c::{Read, Write, WriteRead};
 
 #[cfg(feature = "stm32l0x2")]
 use crate::dma;
+#[cfg(feature = "stm32l0x2")]
+use crate::dma::Buffer;
 use crate::gpio::gpioa::{PA10, PA9};
 use crate::gpio::gpiob::{PB6, PB7};
 use crate::gpio::{AltMode, OpenDrain, Output};
@@ -238,6 +240,7 @@ where
         // Safe, because we're only taking the address of a register.
         let address = &unsafe { &*I::ptr() }.txdr as *const _ as u32;
 
+        let num_words = buffer.len();
         // Safe, because the trait bounds of this method guarantee that the
         // buffer can be read from.
         let transfer = unsafe {
@@ -246,6 +249,62 @@ where
                 token,
                 channel,
                 buffer,
+                num_words,
+                address,
+                dma::Priority::high(),
+                dma::Direction::memory_to_peripheral(),
+            )
+        };
+
+        Transfer {
+            target: self,
+            inner:  transfer,
+        }
+    }
+
+    #[cfg(feature = "stm32l0x2")]
+    pub fn write_some<Channel, Buffer>(mut self,
+        dma:     &mut dma::Handle,
+        channel: Channel,
+        address: u8,
+        buffer:  Pin<Buffer>,
+        num_words: usize,
+    )
+        -> Transfer<Self, Tx<I>, Channel, Buffer, dma::Ready>
+        where
+            Tx<I>:          dma::Target<Channel>,
+            Channel:        dma::Channel,
+            Buffer:         Deref + 'static,
+            Buffer::Target: AsSlice<Element=u8>,
+    {
+        assert!(buffer.len() >= num_words);
+        self.start_transfer(address, buffer.as_slice().len(), RD_WRNW::WRITE);
+
+        // This token represents the transmission capability of I2C and this is
+        // what the `dma::Target` trait is implemented for. It can't be
+        // implemented for `I2c` itself, as that would allow for the user to
+        // pass, for example, a channel that can do I2C RX to `write_all`.
+        //
+        // Theoretically, one could create both `Rx` and `Tx` at the same time,
+        // or create multiple tokens of the same type, and use that to create
+        // multiple simultaneous DMA transfers, which would be wrong and is not
+        // supported by the I2C peripheral. We prevent that by only ever
+        // creating an `Rx` or `Tx` token while we have ownership of `I2c`, and
+        // dropping the token before returning ownership of `I2c` ot the user.
+        let token = Tx(PhantomData);
+
+        // Safe, because we're only taking the address of a register.
+        let address = &unsafe { &*I::ptr() }.txdr as *const _ as u32;
+
+        // Safe, because the trait bounds of this method guarantee that the
+        // buffer can be read from.
+        let transfer = unsafe {
+            dma::Transfer::new(
+                dma,
+                token,
+                channel,
+                buffer,
+                num_words,
                 address,
                 dma::Priority::high(),
                 dma::Direction::memory_to_peripheral(),
@@ -280,6 +339,7 @@ where
         // Safe, because we're only taking the address of a register.
         let address = &unsafe { &*I::ptr() }.rxdr as *const _ as u32;
 
+        let num_words = buffer.len();
         // Safe, because the trait bounds of this method guarantee that the
         // buffer can be written to.
         let transfer = unsafe {
@@ -288,6 +348,53 @@ where
                 token,
                 channel,
                 buffer,
+                num_words,
+                address,
+                dma::Priority::high(),
+                dma::Direction::peripheral_to_memory(),
+            )
+        };
+
+        Transfer {
+            target: self,
+            inner:  transfer,
+        }
+    }
+
+    #[cfg(feature = "stm32l0x2")]
+    pub fn read_some<Channel, Buffer>(mut self,
+        dma:       &mut dma::Handle,
+        channel:   Channel,
+        address:   u8,
+        buffer:    Pin<Buffer>,
+        num_words: usize,
+    )
+        -> Transfer<Self, Rx<I>, Channel, Buffer, dma::Ready>
+        where
+            Rx<I>:          dma::Target<Channel>,
+            Channel:        dma::Channel,
+            Buffer:         DerefMut + 'static,
+            Buffer::Target: AsMutSlice<Element=u8>,
+    {
+        assert!(buffer.len() >= num_words);
+        self.start_transfer(address, buffer.as_slice().len(), RD_WRNW::READ);
+
+        // See explanation of tokens in `write_all`.
+        let token = Rx(PhantomData);
+
+        // Safe, because we're only taking the address of a register.
+        let address = &unsafe { &*I::ptr() }.rxdr as *const _ as u32;
+
+        let num_words = buffer.len();
+        // Safe, because the trait bounds of this method guarantee that the
+        // buffer can be written to.
+        let transfer = unsafe {
+            dma::Transfer::new(
+                dma,
+                token,
+                channel,
+                buffer,
+                num_words,
                 address,
                 dma::Priority::high(),
                 dma::Direction::peripheral_to_memory(),

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -378,27 +378,10 @@ macro_rules! usart {
                         Buffer::Target: AsMutSlice<Element=u8>,
                         Channel:        dma::Channel,
                 {
-                    // Safe, because we're only taking the address of a
-                    // register.
-                    let address =
-                        &unsafe { &*$USARTX::ptr() }.rdr as *const _ as u32;
-
                     let num_words = (*buffer).len();
-                    // Safe, because the trait bounds of this method guarantee
-                    // that the buffer can be written to.
-                    unsafe {
-                        dma::Transfer::new(
-                            dma,
-                            self,
-                            channel,
-                            buffer,
-                            num_words,
-                            address,
-                            dma::Priority::high(),
-                            dma::Direction::peripheral_to_memory(),
-                        )
-                    }
+                    self.read_some(dma, buffer, num_words, channel)
                 }
+
                 pub fn read_some<Buffer, Channel>(self,
                     dma:     &mut dma::Handle,
                     buffer:  Pin<Buffer>,
@@ -530,26 +513,8 @@ macro_rules! usart {
                         Buffer::Target: AsSlice<Element=u8>,
                         Channel:        dma::Channel,
                 {
-                    // Safe, because we're only taking the address of a
-                    // register.
-                    let address =
-                        &unsafe { &*$USARTX::ptr() }.tdr as *const _ as u32;
-
                     let num_words = (*buffer).len();
-                    // Safe, because the trait bounds of this method guarantee
-                    // that the buffer can be read from.
-                    unsafe {
-                        dma::Transfer::new(
-                            dma,
-                            self,
-                            channel,
-                            buffer,
-                            num_words,
-                            address,
-                            dma::Priority::high(),
-                            dma::Direction::memory_to_peripheral(),
-                        )
-                    }
+                    self.write_some(dma, buffer, num_words, channel)
                 }
 
                 pub fn write_some<Buffer, Channel>(self,


### PR DESCRIPTION
Addresses #41

Required adding `num_words` parameter to `Transfer::new(..)`.  `Transfer::new(..)` will panic if the provided transfer size is larger than the provided buffer length (in words).  