### PR TITLE
Add SPI2, LPUART, and I2C definitions for stm32l0x2/3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ features = ["stm32l0x1", "rt"]
 [dependencies]
 as-slice = "0.1.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
-cortex-m = {version = "0.6.0", features = ["const-fn"] }
+cortex-m = {version = "0.6.1", features = ["const-fn"] }
 cortex-m-rt = "0.6.8"
 cortex-m-semihosting = "0.3.2"
 void = { version = "1.0.2", default-features = false }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -29,9 +29,9 @@ use crate::pac::{
     i2c1::{
         RegisterBlock,
         cr2::RD_WRNW,
-    },
-    I2C1,
+    }
 };
+pub use crate::pac::I2C1;
 use crate::rcc::Rcc;
 use crate::time::Hertz;
 use cast::u8;

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -170,6 +170,8 @@ impl_pins!(
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 impl_pins!(
     LPUART1, PA2, PA3,  AF6;
+    LPUART1, PB10, PB11,  AF4;
+    LPUART1, PB11, PB10,  AF7;
     USART1, PA9,  PA10, AF4;
     USART1, PB6,  PB7,  AF0;
     USART2, PA2,  PA3,  AF4;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -5,6 +5,8 @@ use crate::gpio::gpiob::*;
 use crate::gpio::{AltMode, Floating, Input};
 use crate::hal;
 use crate::pac::SPI1;
+#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+use crate::pac::SPI2;
 use crate::rcc::Rcc;
 use crate::time::Hertz;
 use core::ptr;
@@ -119,6 +121,23 @@ pins! {
             [PA7<Input<Floating>>, AltMode::AF0],
             [PA12<Input<Floating>>, AltMode::AF0],
             [PB5<Input<Floating>>, AltMode::AF0]
+        ]
+}
+
+#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+pins! {
+    SPI2:
+        SCK: [
+            [NoSck, None],
+            [PB13<Input<Floating>>, AltMode::AF0]
+        ]
+        MISO: [
+            [NoMiso, None],
+            [PB14<Input<Floating>>, AltMode::AF0]
+        ]
+        MOSI: [
+            [NoMosi, None],
+            [PB15<Input<Floating>>, AltMode::AF0]
         ]
 }
 
@@ -290,6 +309,12 @@ macro_rules! spi {
     }
 }
 
+#[cfg(feature = "stm32l0x1")]
 spi! {
     SPI1: (spi1, apb2enr, spi1en, apb2_clk),
+}
+
+#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+spi! {
+    SPI2: (spi2, apb1enr, spi2en, apb1_clk),
 }


### PR DESCRIPTION
Tested only on stm32l0x2, but as I understand it, stm32l0x3 is a superset of stm32l0x2?