### PR TITLE
Make sure the prescaler counter is reset when starting a timer

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -172,7 +172,11 @@ macro_rules! timers {
                         }
                     );
 
+                    // Load prescaler value and reset its counter.
+                    // Setting URS makes sure no interrupt is generated.
                     self.tim.cr1.modify(|_, w| w.urs().set_bit());
+                    self.tim.egr.write(|w| w.ug().set_bit());
+
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }
 


### PR DESCRIPTION
The following will not behave correctly. 
```
loop {
    timer.start(6.ms());
    block!(timer.wait());
    timer.start(60.ms());
    block!(timer.wait());
}
```
One would expect that we first wait for 6 ms and then for 60 ms, but since the prescaler counter is not reset between consecutive starts the timing will not be accurate for the second and following calls, in particular if the prescaler factor (PSC-register) had to be changed in `start`.

By setting the UG-bit in EGR the counters will be reset such that each call to `start` will behave the same. 

A similar thing is done in the corresponding timer function in [stm32f1xx-hal](https://docs.rs/stm32f1xx-hal/0.4.0/src/stm32f1xx_hal/timer.rs.html#187).

This was tested on the STM32L051K8U6. 