### PR TITLE
RNG driver

### DIFF
--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -1,0 +1,37 @@
+#![no_main]
+#![no_std]
+//#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{pac, prelude::*, rng, rcc::Config, syscfg::SYSCFG};
+
+use core::fmt::Write;
+use stm32l0xx_hal::serial;
+use stm32l0xx_hal::rng::Rng;
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+    let cp = cortex_m::Peripherals::take().unwrap();
+
+    let mut rcc = dp.RCC.freeze(Config::hsi16());
+    let mut syscfg = SYSCFG::new(dp.SYSCFG_COMP, &mut rcc);
+
+    // constructor initializes 48 MHz clock that RNG requires
+    let mut rng = Rng::new(dp.RNG, &mut rcc, &mut syscfg, dp.CRS);
+
+    loop {
+        // enable starts the ADC conversions that generate the random number
+        rng.enable();
+        // wait until the flag flips; interrupt driven is possible but no implemented
+        rng.wait();
+        // reading the result clears the ready flag
+        let val = rng.take_result();
+        // can save some power by disabling until next random number needed
+        rng.disable();
+    }
+}

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,64 @@
+use crate::rcc::Rcc;
+use crate::syscfg::SYSCFG;
+use crate::pac;
+
+pub use crate::pac::{rng, RNG};
+
+
+pub struct Rng {
+    rng: RNG
+}
+
+impl Rng {
+    // initializes the peripheral after enabling 48 MHz clock
+    pub fn new(rng: RNG, rcc: &mut Rcc, syscfg: &mut SYSCFG, crs: pac::CRS) -> Rng {
+
+        // enable 48 MHz clock which feed RNG and USB
+        rcc.enable48_mhz(syscfg, crs);
+
+        // Reset peripheral
+        rcc.rb.ahbrstr.modify(|_, w| w.rngrst().set_bit());
+        rcc.rb.ahbrstr.modify(|_, w| w.rngrst().clear_bit());
+
+        // Enable peripheral clock
+        rcc.rb.ahbenr.modify(|_, w| w.rngen().set_bit());
+
+        rng.cr.write(|w| 
+            w
+                .rngen().set_bit()
+                .ie().clear_bit()
+        );
+
+        let mut ret = Self {
+            rng
+        };
+
+        ret.enable();
+
+        ret
+    }
+
+    pub fn enable(&mut self) {
+        self.rng.cr.write(|w| 
+            w
+                .rngen().set_bit()
+                .ie().clear_bit()
+        );
+    }
+
+    pub fn disable(&mut self) {
+        self.rng.cr.modify(|_, w| 
+            w
+                .rngen().clear_bit()
+                .ie().clear_bit()
+        );
+    }
+
+    pub fn wait(&mut self) {
+        while self.rng.sr.read().drdy().bit_is_clear() {}
+    }
+
+    pub fn take_result(&mut self) -> u32 {
+        self.rng.dr.read().bits()
+    }
+}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -31,37 +31,7 @@ use crate::{
 /// initialization. After calling this method, you need `stm32-usbd` to actually
 /// do anything useful with the USB peripheral.
 pub fn init(rcc: &mut Rcc, syscfg: &mut SYSCFG, crs: pac::CRS) {
-    // Reset CRS peripheral
-    rcc.rb.apb1rstr.modify(|_, w| w.crsrst().set_bit());
-    rcc.rb.apb1rstr.modify(|_, w| w.crsrst().clear_bit());
-
-    // Enable CRS peripheral
-    rcc.rb.apb1enr.modify(|_, w| w.crsen().set_bit());
-
-    // Initialize CRS
-    crs.cfgr.write(|w|
-        // Select LSE as synchronization source
-        unsafe { w.syncsrc().bits(0b01) }
-    );
-    crs.cr.write(|w|
-        w
-            .autotrimen().set_bit()
-            .cen().set_bit()
-    );
-
-    // Enable VREFINT reference for HSI48 oscillator
-    syscfg.syscfg.cfgr3.modify(|_, w|
-        w
-            .enref_rc48mhz().set_bit()
-            .en_bgap().set_bit()
-    );
-
-    // Select HSI48 as USB clock
-    rcc.rb.ccipr.modify(|_, w| w.hsi48msel().set_bit());
-
-    // Enable dedicated USB clock
-    rcc.rb.crrcr.modify(|_, w| w.hsi48on().set_bit());
-    while rcc.rb.crrcr.read().hsi48rdy().bit_is_clear() {};
+    rcc.enable48_mhz(syscfg, crs);
 
     // Reset USB peripheral
     rcc.rb.apb1rstr.modify(|_, w| w.usbrst().set_bit());


### PR DESCRIPTION
Provides a simple synchronous RNG driver and example. Refactor enable 48 MHz code from USB driver to make it accessible via RCC.