### PR TITLE
Mark a few functions as inline

### DIFF
--- a/src/exti.rs
+++ b/src/exti.rs
@@ -34,6 +34,10 @@ pub fn line_is_triggered(reg: u32, line: u8) -> bool {
 }
 
 impl ExtiExt for EXTI {
+    // `port`, `line` and `edge` are almost always constants, so make sure they can be
+    // constant-propagated by marking the function as `#[inline]`. This saves ~600 Bytes in some
+    // simple apps (eg. the `pwr.rs` example).
+    #[inline]
     fn listen(&self, syscfg: &mut SYSCFG, port: gpio::Port, line: u8, edge: TriggerEdge) {
         assert!(line <= 22);
         assert_ne!(line, 18);

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -93,6 +93,7 @@ pub struct Config {
 }
 
 impl Default for Config {
+    #[inline]
     fn default() -> Config {
         Config {
             mux: ClockSrc::MSI(MSIRange::default()),
@@ -104,26 +105,31 @@ impl Default for Config {
 }
 
 impl Config {
+    #[inline]
     pub fn clock_src(mut self, mux: ClockSrc) -> Self {
         self.mux = mux;
         self
     }
 
+    #[inline]
     pub fn ahb_pre(mut self, pre: AHBPrescaler) -> Self {
         self.ahb_pre = pre;
         self
     }
 
+    #[inline]
     pub fn apb1_pre(mut self, pre: APBPrescaler) -> Self {
         self.apb1_pre = pre;
         self
     }
 
+    #[inline]
     pub fn apb2_pre(mut self, pre: APBPrescaler) -> Self {
         self.apb2_pre = pre;
         self
     }
 
+    #[inline]
     pub fn hsi16() -> Config {
         Config {
             mux: ClockSrc::HSI16,
@@ -133,6 +139,7 @@ impl Config {
         }
     }
 
+    #[inline]
     pub fn msi(range: MSIRange) -> Config {
         Config {
             mux: ClockSrc::MSI(range),
@@ -142,6 +149,7 @@ impl Config {
         }
     }
 
+    #[inline]
     pub fn pll(pll_src: PLLSource, pll_mul: PLLMul, pll_div: PLLDiv) -> Config {
         Config {
             mux: ClockSrc::PLL(pll_src, pll_mul, pll_div),
@@ -151,6 +159,7 @@ impl Config {
         }
     }
 
+    #[inline]
     pub fn hse<T>(freq: T) -> Config
     where
         T: Into<Hertz>,
@@ -176,6 +185,10 @@ pub trait RccExt {
 }
 
 impl RccExt for RCC {
+    // `cfgr` is almost always a constant, so make sure it can be constant-propagated properly by
+    // marking this function and all `Config` constructors and setters as `#[inline]`.
+    // This saves ~900 Bytes for the `pwr.rs` example.
+    #[inline]
     fn freeze(self, cfgr: Config) -> Rcc {
         let (sys_clk, sw_bits) = match cfgr.mux {
             ClockSrc::MSI(range) => {


### PR DESCRIPTION
This saves 1.5 KiB of binary size in the `pwr.rs` example.

See comments for explanations.