### PR TITLE
gpio: Enable all GPIO for all targets

### DIFF
--- a/examples/serial_dma_async.rs
+++ b/examples/serial_dma_async.rs
@@ -62,8 +62,8 @@ fn main() -> ! {
     // enqueue as many buffers as available into rx_buffers
     unsafe {
         // putting the same pointer in here twice would be a big mistake
-        rx_buffers.enqueue(Pin::new(&mut BUFFER_1)).unwrap();;
-        rx_buffers.enqueue(Pin::new(&mut BUFFER_2)).unwrap();;
+        rx_buffers.enqueue(Pin::new(&mut BUFFER_1)).unwrap();
+        rx_buffers.enqueue(Pin::new(&mut BUFFER_2)).unwrap();
     }
 
     let dma_handle = &mut dma.handle;

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -57,13 +57,9 @@ impl ExtiExt for EXTI {
         let port_bm = match port {
             gpio::Port::PA => 0,
             gpio::Port::PB => 1,
-            #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
             gpio::Port::PC => 2,
-            #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
             gpio::Port::PD => 3,
-            #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
             gpio::Port::PE => 4,
-            #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
             gpio::Port::PH => {
                 assert!((line < 2) | (line == 9) | (line == 10));
                 5

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -62,14 +62,6 @@ pub(crate) enum AltMode {
     AF7 = 7,
 }
 
-#[cfg(feature = "stm32l0x1")]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Port {
-    PA,
-    PB,
-}
-
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Port {
     PA,
@@ -505,7 +497,6 @@ gpio!(GPIOB, gpiob, iopben, PB, [
     PB15: (pb15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 gpio!(GPIOC, gpioc, iopcen, PC, [
     PC0: (pc0, 0, Input<Floating>),
     PC1: (pc1, 1, Input<Floating>),
@@ -525,7 +516,6 @@ gpio!(GPIOC, gpioc, iopcen, PC, [
     PC15: (pc15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 gpio!(GPIOD, gpiod, iopden, PD, [
     PD0: (pd0, 0, Input<Floating>),
     PD1: (pd1, 1, Input<Floating>),
@@ -545,7 +535,6 @@ gpio!(GPIOD, gpiod, iopden, PD, [
     PD15: (pd15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 gpio!(GPIOE, gpioe, iopeen, PE, [
     PE0:  (pe0,  0,  Input<Floating>),
     PE1:  (pe1,  1,  Input<Floating>),
@@ -565,9 +554,9 @@ gpio!(GPIOE, gpioe, iopeen, PE, [
     PE15: (pe15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 gpio!(GPIOH, gpioh, iophen, PH, [
-    PH0: (ph0, 0, Input<Floating>),
-    PH1: (ph1, 1, Input<Floating>),
-    PH2: (ph2, 2, Input<Floating>),
+    PH0:  (ph0,  0,  Input<Floating>),
+    PH1:  (ph1,  1,  Input<Floating>),
+    PH9:  (ph9,  9,  Input<Floating>),
+    PH10: (ph10, 10, Input<Floating>),
 ]);


### PR DESCRIPTION
For some reason, GPIOC and GPIOD were disabled for the stm32l0x1, but these GPIO banks are present in the PAC (and in the datasheet).