### PR TITLE
Add an API for temporary GPIO reconfiguration

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -4,7 +4,7 @@ use core::ops::Deref;
 use cortex_m::interrupt;
 
 use crate::gpio::gpioa::{PA0, PA1, PA2, PA3};
-use crate::gpio::AltMode;
+use crate::gpio::{AltMode, PinMode};
 use crate::hal;
 use crate::pac::{tim2, TIM2, TIM3};
 use crate::rcc::Rcc;
@@ -251,7 +251,7 @@ macro_rules! impl_pin {
     ) => {
         $(
             $(
-                impl<State> Pin<$instance, $channel> for $name<State> {
+                impl<State: PinMode> Pin<$instance, $channel> for $name<State> {
                     fn setup(&self) {
                         self.set_alt_mode(AltMode::$alternate_function);
                     }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,7 +3,7 @@ use core::marker::PhantomData;
 use core::ptr;
 
 use crate::gpio::gpioa::*;
-use crate::gpio::AltMode;
+use crate::gpio::{PinMode, AltMode};
 use crate::hal;
 use crate::hal::prelude::*;
 pub use crate::pac::USART2;
@@ -159,7 +159,7 @@ pub trait Pins<USART> {
 macro_rules! impl_pins {
     ($($instance:ty, $tx:ident, $rx:ident, $alt:ident;)*) => {
         $(
-            impl<Tx, Rx> Pins<$instance> for ($tx<Tx>, $rx<Rx>) {
+            impl<Tx: PinMode, Rx: PinMode> Pins<$instance> for ($tx<Tx>, $rx<Rx>) {
                 fn setup(&self) {
                     self.0.set_alt_mode(AltMode::$alt);
                     self.1.set_alt_mode(AltMode::$alt);


### PR DESCRIPTION
This eliminates a frequent annoying pattern in embedded Rust when having to dynamically change the configuration of a pin. Where you previously would have to dance the `Option` dance:

```rust
static mut PIN: Option<PB2<Input<Floating>>> = ...;

let mut out = PIN.take().unwrap().into_push_pull_output();
// do stuff with `pin`
PIN = Some(out.into_floating_input());  // put it back
```

With this API you can instead do this:

```rust
static mut PIN: PB2<Input<Floating>> = ...;

PIN.with_push_pull_output(|pin| {
    // do stuff with `pin`
});
```

Of course, this doesn't fix cases where the configuration changes *globally* and would need to be stored back into the `PIN` resource, but it should still be helpful.

Please carefully review the bit manipulation ~~as I have not yet tested this~~ (I have lightly tested this now and it seems to work)

cc @lthiery 