### PR TITLE
Add support for continous conversions to ADC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,10 @@ opt-level = "s"
 
 
 [[example]]
+name = "adc_cont"
+required-features = ["stm32l0x2"]
+
+[[example]]
 name = "aes_ecb"
 required-features = ["stm32l082"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,10 @@ name = "adc_cont"
 required-features = ["stm32l0x2"]
 
 [[example]]
+name = "adc_multi"
+required-features = ["stm32l0x2"]
+
+[[example]]
 name = "adc_trig"
 required-features = ["stm32l0x2"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,10 @@ name = "adc_cont"
 required-features = ["stm32l0x2"]
 
 [[example]]
+name = "adc_trig"
+required-features = ["stm32l0x2"]
+
+[[example]]
 name = "aes_ecb"
 required-features = ["stm32l082"]
 

--- a/examples/adc_cont.rs
+++ b/examples/adc_cont.rs
@@ -61,6 +61,7 @@ fn main() -> ! {
     // Start reading ADC values
     let mut adc = adc.start(
         a0,
+        None,
         &mut dma.handle,
         dma.channels.channel1,
         buffer,

--- a/examples/adc_cont.rs
+++ b/examples/adc_cont.rs
@@ -1,0 +1,92 @@
+//! Example showing continuous ADC
+
+
+#![no_main]
+#![no_std]
+
+
+extern crate panic_halt;
+
+
+use core::{
+    fmt::Write as _,
+    pin::Pin,
+};
+
+use cortex_m_rt::entry;
+// use nb::block;
+use stm32l0xx_hal::{
+    prelude::*,
+    dma::DMA,
+    pac,
+    rcc,
+    serial,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcc   = dp.RCC.freeze(rcc::Config::hsi16());
+    let     adc   = dp.ADC.constrain(&mut rcc);
+    let mut dma   = DMA::new(dp.DMA1, &mut rcc);
+    let     gpioa = dp.GPIOA.split(&mut rcc);
+
+    // The A0 connector on the B-L072Z-LRWAN1 Discovery kit
+    let a0 = gpioa.pa0.into_analog();
+
+    // Connected to the host computer via the ST-LINK
+    let tx = gpioa.pa2;
+    let rx = gpioa.pa3;
+
+    // Initialize USART for test output
+    let (mut tx, _) = dp.USART2
+        .usart(
+            (tx, rx),
+            serial::Config::default()
+                .baudrate(115_200.bps()),
+            &mut rcc,
+        )
+        .unwrap()
+        .split();
+
+    // Create the buffer we're going to use for DMA.
+    //
+    // This is safe, since this is the main function, and it's only executed
+    // once. This means there is no other code accessing this `static`.
+    static mut BUFFER: [u16; 256] = [0; 256];
+    let buffer = Pin::new(unsafe { &mut BUFFER });
+
+    // Start reading ADC values
+    let mut adc = adc.start(
+        a0,
+        &mut dma.handle,
+        dma.channels.channel1,
+        buffer,
+    );
+
+    loop {
+        let read_available = match adc.read_available() {
+            Ok(read_available) => {
+                read_available
+            }
+            Err(err) => {
+                write!(tx, "Error reading available values: {:?}\r\n", err).unwrap();
+                continue;
+            }
+        };
+
+        for val in read_available {
+            // Printing values out is way too slow to process all the values
+            // being created, meaning we're going to see buffer overruns all the
+            // time.
+            //
+            // For this reason, we're ignoring buffer overrun errors here, and
+            // just process any values that were put into the buffer for us.
+            if let Ok(val) = val {
+                write!(tx, "{}\r\n", val).unwrap();
+            }
+        }
+    }
+}

--- a/examples/adc_multi.rs
+++ b/examples/adc_multi.rs
@@ -1,0 +1,88 @@
+//! Example showing continuous ADC with hardware trigger
+
+
+#![no_main]
+#![no_std]
+
+
+extern crate panic_halt;
+
+
+use core::{
+    fmt::Write as _,
+    pin::Pin,
+};
+
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    prelude::*,
+    adc,
+    dma::DMA,
+    pac::{
+        self,
+        tim2::cr2::MMS_A,
+    },
+    rcc,
+    serial,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcc   = dp.RCC.freeze(rcc::Config::hsi16());
+    let     adc   = dp.ADC.constrain(&mut rcc);
+    let mut dma   = DMA::new(dp.DMA1, &mut rcc);
+    let     gpioa = dp.GPIOA.split(&mut rcc);
+
+    // Connected to the host computer via the ST-LINK
+    let tx = gpioa.pa2;
+    let rx = gpioa.pa3;
+
+    // Initialize USART for test output
+    let (mut tx, _) = dp.USART2
+        .usart(
+            (tx, rx),
+            serial::Config::default()
+                .baudrate(115_200.bps()),
+            &mut rcc,
+        )
+        .unwrap()
+        .split();
+
+    // Create the buffer we're going to use for DMA.
+    //
+    // This is safe, since this is the main function, and it's only executed
+    // once. This means there is no other code accessing this `static`.
+    static mut BUFFER: [u16; 256] = [0; 256];
+    let buffer = Pin::new(unsafe { &mut BUFFER });
+
+    // Let's select some channels
+    let mut channels = adc::Channels::from(gpioa.pa0.into_analog());
+    channels.add(gpioa.pa1.into_analog());
+    channels.add(gpioa.pa4.into_analog());
+    channels.add(gpioa.pa5.into_analog());
+
+    // Start reading ADC values
+    let mut adc = adc.start(
+        channels,
+        Some(adc::Trigger::TIM2_TRGO),
+        &mut dma.handle,
+        dma.channels.channel1,
+        buffer,
+    );
+
+    // Enable trigger output for TIM2. This must happen after ADC has been
+    // configured.
+    dp.TIM2
+        .timer(1u32.hz(), &mut rcc)
+        .select_master_mode(MMS_A::UPDATE);
+
+    loop {
+        for val in adc.read_available().unwrap() {
+            write!(tx, "{}\r\n", val.unwrap()).unwrap();
+        }
+    }
+}

--- a/examples/adc_trig.rs
+++ b/examples/adc_trig.rs
@@ -1,0 +1,85 @@
+//! Example showing continuous ADC with hardware trigger
+
+
+#![no_main]
+#![no_std]
+
+
+extern crate panic_halt;
+
+
+use core::{
+    fmt::Write as _,
+    pin::Pin,
+};
+
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    prelude::*,
+    adc,
+    dma::DMA,
+    pac::{
+        self,
+        tim2::cr2::MMS_A,
+    },
+    rcc,
+    serial,
+};
+
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    let mut rcc   = dp.RCC.freeze(rcc::Config::hsi16());
+    let     adc   = dp.ADC.constrain(&mut rcc);
+    let mut dma   = DMA::new(dp.DMA1, &mut rcc);
+    let     gpioa = dp.GPIOA.split(&mut rcc);
+
+    // The A0 connector on the B-L072Z-LRWAN1 Discovery kit
+    let a0 = gpioa.pa0.into_analog();
+
+    // Connected to the host computer via the ST-LINK
+    let tx = gpioa.pa2;
+    let rx = gpioa.pa3;
+
+    // Initialize USART for test output
+    let (mut tx, _) = dp.USART2
+        .usart(
+            (tx, rx),
+            serial::Config::default()
+                .baudrate(115_200.bps()),
+            &mut rcc,
+        )
+        .unwrap()
+        .split();
+
+    // Create the buffer we're going to use for DMA.
+    //
+    // This is safe, since this is the main function, and it's only executed
+    // once. This means there is no other code accessing this `static`.
+    static mut BUFFER: [u16; 256] = [0; 256];
+    let buffer = Pin::new(unsafe { &mut BUFFER });
+
+    // Start reading ADC values
+    let mut adc = adc.start(
+        a0,
+        Some(adc::Trigger::TIM2_TRGO),
+        &mut dma.handle,
+        dma.channels.channel1,
+        buffer,
+    );
+
+    // Enable trigger output for TIM2. This must happen after ADC has been
+    // configured.
+    dp.TIM2
+        .timer(1u32.hz(), &mut rcc)
+        .select_master_mode(MMS_A::UPDATE);
+
+    loop {
+        for val in adc.read_available().unwrap() {
+            write!(tx, "{}\r\n", val.unwrap()).unwrap();
+        }
+    }
+}

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -117,11 +117,14 @@ impl Adc<Ready> {
             .smpr
             .modify(|_, w| w.smp().bits(self.sample_time as u8));
     }
+}
 
+impl<State> Adc<State> {
     pub fn release(self) -> ADC {
         self.rb
     }
 }
+
 
 pub trait AdcExt {
     fn constrain(self, rcc: &mut Rcc) -> Adc<Ready>;

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,8 +1,13 @@
 //! # Analog to Digital converter
-use crate::gpio::*;
-use crate::hal::adc::{Channel, OneShot};
-use crate::pac::ADC;
-use crate::rcc::Rcc;
+
+
+use crate::{
+    gpio::*,
+    hal::adc::{Channel, OneShot},
+    pac::ADC,
+    rcc::Rcc,
+};
+
 
 /// ADC Result Alignment
 #[derive(PartialEq)]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,11 +1,30 @@
 //! # Analog to Digital converter
 
 
+#[cfg(feature = "stm32l0x2")]
+use core::{
+    ops::DerefMut,
+    pin::Pin,
+    sync::atomic::{
+        compiler_fence,
+        Ordering,
+    },
+};
+
+#[cfg(feature = "stm32l0x2")]
+use as_slice::AsMutSlice;
+
 use crate::{
     gpio::*,
     hal::adc::{Channel, OneShot},
     pac::ADC,
     rcc::Rcc,
+};
+
+#[cfg(feature = "stm32l0x2")]
+use crate::dma::{
+    self,
+    Buffer as _,
 };
 
 
@@ -115,6 +134,113 @@ impl Adc<Ready> {
     pub fn set_precision(&mut self, precision: Precision) {
         self.precision = precision;
     }
+
+    /// Starts a continuous conversion process
+    ///
+    /// The `channel` argument specifies which channel should be converted.
+    ///
+    /// In addition to the preceeding argument that configures the ADC,
+    /// additional arguments are required to configure the DMA transfer that is
+    /// used to read the results from the ADC:
+    /// - `dma` is a handle to the DMA peripheral.
+    /// - `dma_chan` is the DMA channel used for the transfer. It needs to be
+    ///   one of the channels that supports the ADC peripheral.
+    /// - `buffer` is the buffer used to buffer the conversion results.
+    ///
+    /// # Panics
+    ///
+    /// Panics, if `buffer` is larger than 65535.
+    #[cfg(feature = "stm32l0x2")]
+    pub fn start<Chan, DmaChan, Buf>(mut self,
+        channel:  Chan,
+        dma:      &mut dma::Handle,
+        dma_chan: DmaChan,
+        buffer:   Pin<Buf>,
+    )
+        -> Adc<Active<DmaChan, Buf>>
+        where
+            DmaToken:    dma::Target<DmaChan>,
+            Chan:        Channel<Self, ID=u8>,
+            Buf:         DerefMut + 'static,
+            Buf::Target: AsMutSlice<Element=u16>,
+            DmaChan:     dma::Channel,
+    {
+        // The ADC can support only one DMA transfer at a time, so only one of
+        // these DMA tokens must exist at a time. We guarantee this by only
+        // creating it in this method, that can only be called in the ADC's
+        // `Ready` state. The DMA transfer is ended and the token associated
+        // with it is dropped before we return to the `Ready` state.
+        let dma_token = DmaToken(());
+
+        let num_words = (*buffer).len();
+
+        // Safe, because we're only taking the address of a register.
+        let address = &self.rb.dr as *const _ as u32;
+
+        // The cast to `u16` could truncate the value, but if it does,
+        // `Transfer::new` is going to panic anyway.
+        let buffer_unsafe = Buffer {
+            ptr: buffer.as_ptr(),
+            len: buffer.len() as u16,
+            pos: 0,
+
+            r_gt_w: false,
+        };
+
+        // Safe, because the trait bounds of this method guarantee that the
+        // buffer can be written to.
+        let transfer =
+            unsafe {
+                dma::Transfer::new(
+                    dma,
+                    dma_token,
+                    dma_chan,
+                    buffer,
+                    num_words,
+                    address,
+                    dma::Priority::high(),
+                    dma::Direction::peripheral_to_memory(),
+                    true,
+                )
+            }
+            .start();
+
+        self.power_up();
+        self.configure(&channel, true);
+
+        Adc {
+            rb:          self.rb,
+            sample_time: self.sample_time,
+            align:       self.align,
+            precision:   self.precision,
+            _state:      Active { buffer: buffer_unsafe, transfer },
+        }
+    }
+}
+
+#[cfg(feature = "stm32l0x2")]
+impl<DmaChan, Buffer> Adc<Active<DmaChan, Buffer>>
+    where DmaChan: dma::Channel,
+{
+    /// Returns an iterator over all currently available values
+    ///
+    /// The iterator iterates over all buffered values. It returns `None`, once
+    /// the end of the buffer has been reached.
+    pub fn read_available(&mut self)
+        -> Result<impl Iterator<Item=Result<u16, Error>> + '_, Error>
+    {
+        if self.rb.isr.read().ovr().is_overrun() {
+            self.rb.isr.write(|w| w.ovr().clear());
+            return Err(Error::AdcOverrun);
+        }
+
+        Ok(
+            ReadAvailable {
+                buffer:   &mut self._state.buffer,
+                transfer: &mut self._state.transfer,
+            }
+        )
+    }
 }
 
 impl<State> Adc<State> {
@@ -134,7 +260,7 @@ impl<State> Adc<State> {
         while self.rb.cr.read().aden().bit_is_set() {}
     }
 
-    fn configure<Chan>(&mut self, _channel: &Chan)
+    fn configure<Chan>(&mut self, _channel: &Chan, cont: bool)
         where
             Chan: Channel<Adc<Ready>, ID=u8>,
     {
@@ -144,8 +270,14 @@ impl<State> Adc<State> {
             //
             // The `bits` method is not unsafe on STM32L0x1, so we need to
             // suppress the warning there.
-            let w = w.res().bits(self.precision as u8);
-            w.align().bit(self.align == Align::Left)
+            w
+                .res().bits(self.precision as u8)
+                .cont().bit(cont)
+                .align().bit(self.align == Align::Left)
+                // DMA circular mode
+                .dmacfg().set_bit()
+                // Generate DMA requests
+                .dmaen().set_bit()
         });
 
         self.rb
@@ -172,7 +304,7 @@ where
 
     fn read(&mut self, pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
         self.power_up();
-        self.configure(pin);
+        self.configure(pin, false);
 
         while self.rb.isr.read().eos().bit_is_clear() {}
 
@@ -192,12 +324,230 @@ where
 /// Indicates that the ADC peripheral is ready
 pub struct Ready;
 
+/// Indicates that the ADC peripheral is performing conversions
+#[cfg(feature = "stm32l0x2")]
+pub struct Active<DmaChan, Buf> {
+    transfer: dma::Transfer<DmaToken, DmaChan, Buf, dma::Started>,
+    buffer:   Buffer,
+}
+
+
+/// Provides access to the buffer that the DMA writes ADC values into
+///
+/// Since the DMA transfer takes ownership of the buffer, we need to access it
+/// with unsafe means. This struct is a safe wrapper around this unsafe access.
+#[cfg(feature = "stm32l0x2")]
+struct Buffer {
+    ptr: *const u16,
+    len: u16,
+    pos: u16,
+
+    /// Indicates order of read and write indices
+    ///
+    /// This is initially `false`, indicating that the read position (the `pos`
+    /// field) is smaller than or equal to the write position (internally
+    /// managed by the DMA peripheral).
+    ///
+    /// Once the write position wraps around the buffer boundary, this becomes
+    /// `true` until the read position also wraps around.
+    r_gt_w: bool,
+}
+
+#[cfg(feature = "stm32l0x2")]
+impl Buffer {
+    fn read<T, C, B>(&mut self, transfer: &dma::Transfer<T, C, B, dma::Started>)
+        -> Option<Result<u16, Error>>
+        where C: dma::Channel
+    {
+        let transfer_state = self.transfer_state(transfer);
+        if self.check_overrun(transfer_state) {
+            return Some(Err(Error::BufferOverrun));
+        }
+
+        if self.pos == transfer_state.pos {
+            // No overrun detected, but read and write positions are equal. This
+            // can only mean that the buffer is empty.
+            return None;
+        }
+
+        // Safe, as we know that `ptr` and `len` define a valid buffer, and we
+        // make sure that `pos <= len`. There's a race condition between this
+        // line and the DMA peripheral, of course, but we take care of that with
+        // these overrun checks.
+        //
+        // The cast is fine too. This is a 32-bit platform, so casting a `u16`
+        // to an `isize` will never truncate the value.
+        compiler_fence(Ordering::SeqCst);
+        let value = unsafe { *self.ptr.offset(self.pos as isize) };
+        compiler_fence(Ordering::SeqCst);
+
+        // At this point we know that there was no overrun before we started
+        // reading, but of course the DMA might have overtaken us since that
+        // check. Let's check again. If there's still no overrun, we know that
+        // our value is valid.
+        let transfer_state = self.transfer_state(transfer);
+        if self.check_overrun(transfer_state) {
+            // Strictly speaking, the overrun might have happened after our
+            // read, and `value` might be valid. No way to know for sure though,
+            // so let's assume overrun.
+            return Some(Err(Error::BufferOverrun));
+        }
+
+        // Now we know that the value we read is totally fine. Let's advance the
+        // read position to finish up here.
+        self.pos = self.pos.wrapping_add(1);
+        if self.pos == 0 || self.pos >= self.len {
+            // We advanced beyond the end of the buffer, which means we need to
+            // wrap around to the beginning.
+            self.pos    = 0;
+            self.r_gt_w = false;
+        }
+
+        Some(Ok(value))
+    }
+
+    fn transfer_state<T, C, B>(&self,
+        transfer: &dma::Transfer<T, C, B, dma::Started>,
+    )
+        -> TransferState
+        where C: dma::Channel
+    {
+        let (remaining, half, complete) = transfer.state();
+        transfer.clear_flags();
+
+        // Let's translate what we got from the DMA peripheral into a write
+        // position that we can compare with our read position.
+        let pos = self.len - remaining;
+
+        TransferState {
+            pos,
+            half,
+            complete,
+        }
+    }
+
+    fn check_overrun(&mut self, transfer_state: TransferState) -> bool {
+        let overrun = self.check_overrun_inner(transfer_state);
+
+        if overrun {
+            // An overrun occured, but that is not a catastrophic error. Values
+            // got lost, but that doesn't mean we can't read the new values
+            // starting now. Let's get the buffer into a consistent state to
+            // make that possible.
+            //
+            // There are various ways to go about this. What we're doing here is
+            // to throw away all values in the buffer and start again with an
+            // empty buffer, because that minimizes the likelihood of getting
+            // another overrun right away.
+            //
+            // Maybe doing the opposite, setting the read position so that the
+            // buffer is full, to minimize lost values, would be better. But
+            // then we should give the user the option to empty the buffer
+            // manually. I've chosen to go with the simpler option for now.
+            self.pos    = transfer_state.pos;
+            self.r_gt_w = false;
+        }
+
+        overrun
+    }
+
+    fn check_overrun_inner(&mut self, transfer_state: TransferState) -> bool {
+        if transfer_state.half && transfer_state.complete {
+            // Each time we attempt a read, we clear both flags. If both flags
+            // are set, then basically anything could have happened in between,
+            // so we have to assume an overrun.
+            //
+            // Please note that it's possible that the DMA has written beyond
+            // the half point and wrapped around, causing both of the flags to
+            // be set, without passing our current reading position. However,
+            // there's no way to distinguish this case from the DMA having
+            // passed those marks multiple times, so we have to be conservative
+            // and assume an overrun.
+            return true;
+        }
+
+        if transfer_state.complete {
+            // The write has wrapped beyond the buffer boundary and started
+            // again at the beginning of the buffer. This is completely normal,
+            // but it affects how we detect an overrun.
+
+            if self.r_gt_w {
+                // The read position was greater than the write position, so if
+                // the write position wrapped, it must have overtaken the read
+                // position. This is an overrun.
+                return true;
+            }
+
+            // The write position has wrapped, so now the read position needs
+            // to be greater than the write position.
+            self.r_gt_w = true;
+        }
+
+        // At this point we know that everything _could_ be alright, judging
+        // from the combination of flags we checked so far. We still need to
+        // compare read and write positions to make sure that we don't actually
+        // have an overrun.
+        if self.r_gt_w {
+            self.pos <= transfer_state.pos
+        }
+        else {
+            self.pos > transfer_state.pos
+        }
+    }
+}
+
+
+/// Internal struct to represent the current state of the DMA transfer
+#[derive(Clone, Copy, Debug)]
+struct TransferState {
+    pos:      u16,
+    half:     bool,
+    complete: bool,
+}
+
+
+/// Iterator over buffered ADC values
+#[cfg(feature = "stm32l0x2")]
+pub struct ReadAvailable<'r, T, C, B> {
+    buffer:   &'r mut Buffer,
+    transfer: &'r dma::Transfer<T, C, B, dma::Started>,
+}
+
+#[cfg(feature = "stm32l0x2")]
+impl<T, C, B> Iterator for ReadAvailable<'_, T, C, B>
+    where C: dma::Channel
+{
+    type Item = Result<u16, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.buffer.read(self.transfer)
+    }
+}
+
 
 /// Used for DMA transfers
 ///
 /// This is an internal implementation detail. It is only public because it
 /// leaks out of a public API in the form of a `where` clause.
 pub struct DmaToken(());
+
+
+/// Represents an ADC error
+#[derive(Debug)]
+pub enum Error {
+    /// Indicates that converted data was not read in time
+    ///
+    /// This happens if either the user or the DMA (depending on mode) did not
+    /// read the converted value before another one was ready.
+    AdcOverrun,
+
+    /// Indicates that values in the internal buffer have been overwritten
+    ///
+    /// This is not a critical error, as a circular buffer is used, and the DMA
+    /// just keeps writing more values. It does mean that some values in the
+    /// buffer were overwritten though.
+    BufferOverrun,
+}
 
 
 macro_rules! int_adc {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -99,6 +99,12 @@ impl Adc<Ready> {
     pub fn set_precision(&mut self, precision: Precision) {
         self.precision = precision;
     }
+}
+
+impl<State> Adc<State> {
+    pub fn release(self) -> ADC {
+        self.rb
+    }
 
     fn power_up(&mut self) {
         self.rb.isr.modify(|_, w| w.adrdy().set_bit());
@@ -116,12 +122,6 @@ impl Adc<Ready> {
         self.rb
             .smpr
             .modify(|_, w| w.smp().bits(self.sample_time as u8));
-    }
-}
-
-impl<State> Adc<State> {
-    pub fn release(self) -> ADC {
-        self.rb
     }
 }
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -193,6 +193,13 @@ where
 pub struct Ready;
 
 
+/// Used for DMA transfers
+///
+/// This is an internal implementation detail. It is only public because it
+/// leaks out of a public API in the form of a `where` clause.
+pub struct DmaToken(());
+
+
 macro_rules! int_adc {
     ($($Chan:ident: ($chan:expr, $en:ident)),+ $(,)*) => {
         $(

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -9,6 +9,17 @@ use crate::{
 };
 
 
+pub trait AdcExt {
+    fn constrain(self, rcc: &mut Rcc) -> Adc<Ready>;
+}
+
+impl AdcExt for ADC {
+    fn constrain(self, rcc: &mut Rcc) -> Adc<Ready> {
+        Adc::new(self, rcc)
+    }
+}
+
+
 /// ADC Result Alignment
 #[derive(PartialEq)]
 pub enum Align {
@@ -127,17 +138,6 @@ impl<State> Adc<State> {
         self.rb
             .smpr
             .modify(|_, w| w.smp().bits(self.sample_time as u8));
-    }
-}
-
-
-pub trait AdcExt {
-    fn constrain(self, rcc: &mut Rcc) -> Adc<Ready>;
-}
-
-impl AdcExt for ADC {
-    fn constrain(self, rcc: &mut Rcc) -> Adc<Ready> {
-        Adc::new(self, rcc)
     }
 }
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -264,7 +264,7 @@ impl<State> Adc<State> {
         where
             Chan: Channel<Adc<Ready>, ID=u8>,
     {
-        self.rb.cfgr1.modify(|_, w| {
+        self.rb.cfgr1.write(|w| {
             w
                 .res().bits(self.precision as u8)
                 .cont().bit(cont)

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -265,11 +265,6 @@ impl<State> Adc<State> {
             Chan: Channel<Adc<Ready>, ID=u8>,
     {
         self.rb.cfgr1.modify(|_, w| {
-            // Safe, as `self.precision` is of type `Precision`, which defines
-            // only valid values.
-            //
-            // The `bits` method is not unsafe on STM32L0x1, so we need to
-            // suppress the warning there.
             w
                 .res().bits(self.precision as u8)
                 .cont().bit(cont)

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -614,6 +614,7 @@ impl<Target, Channel, Buffer> Transfer<Target, Channel, Buffer, dma::Ready>
             address,
             priority,
             dir,
+            false,
         );
 
         Self {

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -27,6 +27,7 @@ use core::{
 use as_slice::AsSlice;
 
 use crate::{
+    adc,
     i2c,
     pac::{
         self,
@@ -471,6 +472,10 @@ macro_rules! impl_target {
 
 // See STM32L0x2 Reference Manual, table 51 (page 267).
 impl_target!(
+    // ADC
+    adc::DmaToken, Channel1, 0;
+    adc::DmaToken, Channel2, 0;
+
     // USART1
     serial::Tx<USART1>, Channel2, 3;
     serial::Tx<USART1>, Channel4, 3;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -273,6 +273,7 @@ where
                 address,
                 dma::Priority::high(),
                 dma::Direction::memory_to_peripheral(),
+                false,
             )
         };
 
@@ -337,6 +338,7 @@ where
                 address,
                 dma::Priority::high(),
                 dma::Direction::peripheral_to_memory(),
+                false,
             )
         };
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -498,6 +498,7 @@ macro_rules! usart {
                             address,
                             dma::Priority::high(),
                             dma::Direction::peripheral_to_memory(),
+                            false,
                         )
                     }
                 }
@@ -609,6 +610,7 @@ macro_rules! usart {
                             address,
                             dma::Priority::high(),
                             dma::Direction::memory_to_peripheral(),
+                            false,
                         )
                     }
                 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,6 @@
 //! Timers
 use crate::hal::timer::{CountDown, Periodic};
-use crate::pac::{TIM2, TIM21, TIM22, TIM3};
+use crate::pac::{TIM2, TIM21, TIM22, TIM3, tim2, tim21, tim22};
 use crate::rcc::{Clocks, Rcc};
 use crate::time::Hertz;
 use cast::{u16, u32};
@@ -83,7 +83,7 @@ impl TimerExt<SYST> for SYST {
 impl Periodic for Timer<SYST> {}
 
 macro_rules! timers {
-    ($($TIM:ident: ($tim:ident, $timXen:ident, $timXrst:ident, $apbenr:ident, $apbrstr:ident, $timclk:ident),)+) => {
+    ($($TIM:ident: ($tim:ident, $timXen:ident, $timXrst:ident, $apbenr:ident, $apbrstr:ident, $timclk:ident, $mms:ty),)+) => {
         $(
             impl TimerExt<$TIM> for $TIM {
                 fn timer<T>(self, timeout: T, rcc: &mut Rcc) -> Timer<$TIM>
@@ -94,7 +94,7 @@ macro_rules! timers {
                 }
             }
 
-            impl Timer<$TIM> {
+            impl Timer<$TIM> where $TIM: GeneralPurposeTimer {
                 /// Configures a TIM peripheral as a periodic count down timer
                 pub fn $tim<T>(tim: $TIM, timeout: T, rcc: &mut Rcc) -> Self
                 where
@@ -142,6 +142,13 @@ macro_rules! timers {
                     // continue
                     self.tim.cr1.modify(|_, w| w.cen().set_bit());
                 }
+
+                /// Select master mode
+                pub fn select_master_mode(&mut self,
+                    variant: <$TIM as GeneralPurposeTimer>::MasterMode,
+                ) {
+                    self.tim.select_master_mode(variant);
+                }
             }
 
             impl CountDown for Timer<$TIM> {
@@ -188,13 +195,32 @@ macro_rules! timers {
             }
 
             impl Periodic for Timer<$TIM> {}
+
+            impl GeneralPurposeTimer for $TIM {
+                type MasterMode = $mms;
+
+                fn select_master_mode(&mut self, variant: Self::MasterMode) {
+                    self.cr2.modify(|_, w| w.mms().variant(variant));
+                }
+            }
         )+
     }
 }
 
 timers! {
-    TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr, apb1_tim_clk),
-    TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr, apb1_tim_clk),
-    TIM21: (tim21, tim21en, tim21rst, apb2enr, apb2rstr, apb2_tim_clk),
-    TIM22: (tim22, tim22en, tim22rst, apb2enr, apb2rstr, apb2_tim_clk),
+    TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr, apb1_tim_clk,
+        tim2::cr2::MMS_A),
+    TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr, apb1_tim_clk,
+        tim2::cr2::MMS_A),
+    TIM21: (tim21, tim21en, tim21rst, apb2enr, apb2rstr, apb2_tim_clk,
+        tim21::cr2::MMS_A),
+    TIM22: (tim22, tim22en, tim22rst, apb2enr, apb2rstr, apb2_tim_clk,
+        tim22::cr2::MMS_A),
+}
+
+
+pub trait GeneralPurposeTimer {
+    type MasterMode;
+
+    fn select_master_mode(&mut self, variant: Self::MasterMode);
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -46,7 +46,7 @@ unsafe impl UsbPeripheral for USB {
     const EP_MEMORY_SIZE: usize = 1024;
 
     fn enable() {
-        let rcc = unsafe { (&*RCC::ptr()) };
+        let rcc = unsafe { &*RCC::ptr() };
 
         cortex_m::interrupt::free(|_| {
             // Enable USB peripheral


### PR DESCRIPTION
Adds support for continuous conversions via DMA to the ADC API. This is of somewhat limited use (as the example shows), as it's impossible to process the data as fast as the ADC can produce it. It requires support for hardware triggers, to become fully usable.

However, this PR adds some valuable infrastructure, like circular DMA transfers and the DMA buffer code in `adc`. I think it's worth getting it merged, as it's a solid base to build upon (which I intend to do).