### PR TITLE
Added all available USART2 pins

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use core::ptr;
 
 use crate::gpio::gpioa::*;
+use crate::gpio::gpiob::*;
 use crate::gpio::{PinMode, AltMode};
 use crate::hal;
 use crate::hal::prelude::*;
@@ -25,7 +26,6 @@ use as_slice::{AsMutSlice, AsSlice};
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 pub use crate::{
     dma,
-    gpio::gpiob::*,
     gpio::gpioc::*,
     gpio::gpiod::*,
     gpio::gpioe::*,
@@ -172,7 +172,10 @@ macro_rules! impl_pins {
 #[cfg(feature = "stm32l0x1")]
 impl_pins!(
     LPUART1, PA2, PA3,  AF6;
+    USART2,  PA2, PA3,  AF4;
     USART2,  PA9, PA10, AF4;
+    USART2,  PA14, PA15, AF4; 
+    USART2,  PB6,  PB7,  AF0;
 );
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]


### PR DESCRIPTION
The serial file only has one set of USART2 pins under the STM32l0x1 feature flag, while the STM32l031 [setting sheet](https://www.st.com/resource/en/datasheet/stm32l031k6.pdf) lists four. 

I added all the available USART2 pins and tested on my Nucleo-L031K6 evaluation board.