### PR TITLE
Add comments about product categories to io-* features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,12 +65,14 @@ stm32l082 = ["stm32l0x2"]
 
 # Features based on the GPIO peripheral version.
 # This determines the pin function mapping of the MCU.
+# The features correspond to the product categories.
+#
 # Note: The easiest way to pick the proper io-* feature is to apply
 # the matching mcu-* feature for your MCU!
-io-STM32L021 = []
-io-STM32L031 = []
-io-STM32L051 = []
-io-STM32L071 = []
+io-STM32L021 = [] # Product category 1
+io-STM32L031 = [] # Product category 2
+io-STM32L051 = [] # Product category 3
+io-STM32L071 = [] # Product category 5
 
 # Physical packages
 ewlcsp49 = []


### PR DESCRIPTION
Initially I was fairly confused on what those "GPIO IP versions" actually mean, but now I'm pretty sure they correspond to the product categories as per "1.4 Product category definition" in the family reference manual.

For example, in the stm32l0x1 Reference Manual:

![2020-04-04-001320_1297x835_scrot](https://user-images.githubusercontent.com/105168/78409091-1a861700-7609-11ea-9e1c-faba03a8b063.png)