### PR TITLE
Cargo.toml: Add usage warning to MCU feature comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ wlcsp36 = []
 wlcsp49 = []
 
 # MCUs
+#
+# Note: These are just aliases for the proper io-* feature and physical
+# package. Do *not* use these features in any `cfg` attributes in the HAL!
 mcu-STM32L010C6Tx = ["io-STM32L031", "lqfp48"]
 mcu-STM32L010F4Px = ["io-STM32L021", "tssop20"]
 mcu-STM32L010K4Tx = ["io-STM32L021", "lqfp32"]


### PR DESCRIPTION
MCU features should only serve as aliases, they should *not* be used in
`cfg` attributes, since the resulting code would be unmaintainable in
the long run.