### PR TITLE
i2c: properly handle bus errors

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -198,6 +198,12 @@ where
     }
     
     fn start_transfer(&mut self, addr: u8, len: usize, direction: RD_WRN_A, autoend : AUTOEND_A) {
+        // Ensure that TX/RX buffers are empty
+        self.i2c.isr.write(|w| w.txe().set_bit());
+        while self.i2c.isr.read().rxne().bit_is_set() {
+            self.i2c.rxdr.read();
+        };
+        
         self.i2c.cr2.write(|w|
             w
                 // Start transfer


### PR DESCRIPTION
In send_byte() wait for TX fifo empty before returning Ok. It would be
better to wait for end of transmission, but there is no such field in
I2C status register.

In recv_byte() return Err if error condition detected while waiting for
byte.

Before starting new transaction ensure that both TX and RX buffers are
empty. There are some corner cases where something may be there.