### PR TITLE
LinkedTimer: Implement initial version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -347,6 +347,10 @@ name = "timer_interrupt_rtic"
 required-features = ["rt"]
 
 [[example]]
+name = "linked_timer_rtic"
+required-features = ["rt", "stm32l0x1", "io-STM32L071"]
+
+[[example]]
 name = "adc_pwm"
 required-features = ["stm32l0x1"]
 

--- a/examples/linked_timer_rtic.rs
+++ b/examples/linked_timer_rtic.rs
@@ -1,0 +1,124 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use core::fmt::Write;
+
+use rtic::app;
+use stm32l0xx_hal::prelude::*;
+use stm32l0xx_hal::{
+    pac,
+    rcc::Config,
+    serial::{self, Serial},
+    time,
+    timer::{LinkedTimer, LinkedTimerPair, Timer},
+};
+
+const LOGGER_FREQUENCY: u32 = 2;
+
+#[app(device = stm32l0xx_hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        serial: Serial<pac::USART1>,
+        timer: Timer<pac::TIM6>,
+        linked_tim2_tim3: LinkedTimerPair<pac::TIM2, pac::TIM3>,
+        linked_tim21_tim22: LinkedTimerPair<pac::TIM21, pac::TIM22>,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        let cp: cortex_m::Peripherals = ctx.core;
+        let dp: pac::Peripherals = ctx.device;
+
+        // Configure the clock
+        let mut rcc = dp.RCC.freeze(Config::hsi16());
+
+        // Get delay provider
+        let mut delay = cp.SYST.delay(rcc.clocks);
+
+        // Initialize serial output on PB6 / PB7
+        let gpiob = dp.GPIOB.split(&mut rcc);
+        let mut serial = Serial::usart1(
+            dp.USART1,
+            gpiob.pb6.into_floating_input(),
+            gpiob.pb7.into_floating_input(),
+            serial::Config::default(),
+            &mut rcc,
+        )
+        .unwrap();
+        writeln!(serial, "Starting example").ok();
+
+        // Configure the linked timers
+        writeln!(serial, "Init TIM2/TIM3...").ok();
+        let linked_tim2_tim3 = LinkedTimerPair::tim2_tim3(dp.TIM2, dp.TIM3, &mut rcc);
+        delay.delay_ms(1000u16); // 1s offset between timer initialization
+        writeln!(serial, "Init TIM21/TIM22...").ok();
+        let linked_tim21_tim22 = LinkedTimerPair::tim21_tim22(dp.TIM21, dp.TIM22, &mut rcc);
+
+        // Configure the logging timer
+        let mut timer = dp.TIM6.timer(LOGGER_FREQUENCY.hz(), &mut rcc);
+        timer.listen();
+
+        init::LateResources {
+            serial,
+            timer,
+            linked_tim2_tim3,
+            linked_tim21_tim22,
+        }
+    }
+
+    #[task(binds = TIM6, resources = [serial, timer, linked_tim2_tim3, linked_tim21_tim22])]
+    fn logger(ctx: logger::Context) {
+        static mut PREV_TIM2_TIM3: u32 = 0;
+        static mut PREV_TIM21_TIM22: u32 = 0;
+
+        // Clear the interrupt flag
+        ctx.resources.timer.clear_irq();
+
+        // Print timer counter
+        print_timer(
+            "TIM2/TIM3   ",
+            ctx.resources.linked_tim2_tim3,
+            ctx.resources.serial,
+            PREV_TIM2_TIM3,
+        );
+        print_timer(
+            "TIM21/TIM22 ",
+            ctx.resources.linked_tim21_tim22,
+            ctx.resources.serial,
+            PREV_TIM21_TIM22,
+        );
+    }
+};
+
+fn print_timer(
+    name: &'static str,
+    timer: &impl LinkedTimer,
+    serial: &mut Serial<pac::USART1>,
+    previous: &mut u32,
+) {
+    // Get the 32 bit counter
+    let cnt = timer.get_counter();
+
+    // Difference between current and previous count
+    let delta = cnt - *previous;
+
+    // Calculate frequency
+    let freq = delta * LOGGER_FREQUENCY / 1000;
+
+    writeln!(
+        serial,
+        "{} count {:>10} (msb={} lsb={} Δ{} {} kHz)",
+        name,
+        cnt,
+        (cnt & 0xffff0000) >> 16,
+        cnt & 0xffff,
+        delta,
+        freq,
+    )
+    .ok();
+
+    // Store current count
+    *previous = cnt;
+}

--- a/examples/linked_timer_rtic.rs
+++ b/examples/linked_timer_rtic.rs
@@ -73,8 +73,21 @@ const APP: () = {
         static mut PREV_TIM2_TIM3: u32 = 0;
         static mut PREV_TIM21_TIM22: u32 = 0;
 
+        // Reset after ~3 seconds
+        static mut TIMES_UNTIL_RESET: u32 = 3 * LOGGER_FREQUENCY;
+
         // Clear the interrupt flag
         ctx.resources.timer.clear_irq();
+
+        // Check reset count
+        if *TIMES_UNTIL_RESET > 1 {
+            *TIMES_UNTIL_RESET -= 1;
+        } else if *TIMES_UNTIL_RESET == 1 {
+            writeln!(ctx.resources.serial, "Reset",).ok();
+            ctx.resources.linked_tim2_tim3.reset();
+            ctx.resources.linked_tim21_tim22.reset();
+            *TIMES_UNTIL_RESET -= 1;
+        }
 
         // Print timer counter
         print_timer(

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -144,7 +144,8 @@ macro_rules! timers {
                 }
 
                 /// Select master mode
-                pub fn select_master_mode(&mut self,
+                pub fn select_master_mode(
+                    &mut self,
                     variant: <$TIM as GeneralPurposeTimer>::MasterMode,
                 ) {
                     self.tim.select_master_mode(variant);
@@ -224,4 +225,120 @@ pub trait GeneralPurposeTimer {
     type MasterMode;
 
     fn select_master_mode(&mut self, variant: Self::MasterMode);
+}
+
+/// Two linked 16 bit timers that form a 32 bit timer.
+pub trait LinkedTimer {
+    /// Return the current 16 bit counter value of the MSB timer.
+    fn get_counter_msb(&self) -> u16;
+
+    /// Return the current 16 bit counter value of the LSB timer.
+    fn get_counter_lsb(&self) -> u16;
+
+    /// Return the current 32 bit counter value.
+    fn get_counter(&self) -> u32;
+}
+
+/// A pair of timers that can be linked.
+///
+/// The two timers are configured so that an overflow of the primary timer
+/// triggers an update on the secondary timer. This way, two 16 bit timers can
+/// be combined to a single 32 bit timer.
+pub struct LinkedTimerPair<PRIMARY, SECONDARY> {
+    /// Timer in primary mode
+    tim_primary: PRIMARY,
+    /// Timer in secondary mode
+    tim_secondary: SECONDARY,
+}
+
+macro_rules! linked_timers {
+    ($(
+        ($PRIMARY:ident, $SECONDARY:ident): (
+            $new:ident,
+            $apbenr:ident, $apbrstr:ident,
+            $master_en:ident, $slave_en:ident,
+            $master_rst:ident, $slave_rst:ident,
+            $mms:ty, $sms:ty, $ts:expr
+        ),
+    )+) => {
+        $(
+            impl LinkedTimerPair<$PRIMARY, $SECONDARY> {
+                /// Create and configure a new `LinkedTimerPair` with the
+                /// specified timers.
+                pub fn $new(tim_primary: $PRIMARY, tim_secondary: $SECONDARY, rcc: &mut Rcc) -> Self {
+                    // Enable timers
+                    rcc.rb.$apbenr.modify(|_, w| w.$master_en().set_bit());
+                    rcc.rb.$apbenr.modify(|_, w| w.$slave_en().set_bit());
+
+                    // Reset timers
+                    rcc.rb.$apbrstr.modify(|_, w| w.$master_rst().set_bit());
+                    rcc.rb.$apbrstr.modify(|_, w| w.$master_rst().clear_bit());
+                    rcc.rb.$apbrstr.modify(|_, w| w.$slave_rst().set_bit());
+                    rcc.rb.$apbrstr.modify(|_, w| w.$slave_rst().clear_bit());
+
+                    // Enable counter
+                    tim_primary.cr1.modify(|_, w| w.cen().set_bit());
+                    tim_secondary.cr1.modify(|_, w| w.cen().set_bit());
+
+                    // In the MMS (Master Mode Selection) register, set the master mode so
+                    // that a rising edge is output on the trigger output TRGO every time
+                    // an update event is generated.
+                    tim_primary.cr2.modify(|_, w| w.mms().variant(<$mms>::UPDATE));
+
+                    // In the SMCR (Slave Mode Control Register), select the
+                    // appropriate internal trigger source (TS).
+                    tim_secondary.smcr.modify(|_, w| w.ts().variant($ts));
+                    // Set the SMS (Slave Mode Selection) register to "external clock mode 1",
+                    // where the rising edges of the selected trigger (TRGI) clock the counter.
+                    tim_secondary.smcr.modify(|_, w| w.sms().variant(<$sms>::EXT_CLOCK_MODE));
+
+                    Self { tim_primary, tim_secondary }
+                }
+            }
+
+            impl LinkedTimer for LinkedTimerPair<$PRIMARY, $SECONDARY> {
+                /// Return the current 16 bit counter value of the primary timer (LSB).
+                fn get_counter_lsb(&self) -> u16 {
+                    self.tim_primary.cnt.read().cnt().bits()
+                }
+
+                /// Return the current 16 bit counter value of the secondary timer (MSB).
+                fn get_counter_msb(&self) -> u16 {
+                    self.tim_secondary.cnt.read().cnt().bits()
+                }
+
+                /// Return the current 32 bit counter value.
+                ///
+                /// Note: Due to the potential for a race condition between
+                /// reading MSB and LSB, it's possible that the registers must
+                /// be re-read once. Therefore reading the counter value is not
+                /// constant time.
+                fn get_counter(&self) -> u32 {
+                    loop {
+                        let msb = self.tim_secondary.cnt.read().cnt().bits() as u32;
+                        let lsb = self.tim_primary.cnt.read().cnt().bits() as u32;
+
+                        // Because the timer is still running at high frequency
+                        // between reading MSB and LSB, it's possible that LSB
+                        // has already overflowed. Therefore we read MSB again
+                        // to check that it hasn't changed.
+                        let msb_again = self.tim_secondary.cnt.read().cnt().bits() as u32;
+                        if msb == msb_again {
+                            return (msb << 16) | lsb;
+                        }
+                    }
+                }
+            }
+        )+
+    }
+}
+
+linked_timers! {
+    // Internal trigger connection: RM0377 table 76
+    (TIM2, TIM3): (tim2_tim3, apb1enr, apb1rstr, tim2en, tim3en, tim2rst, tim3rst, tim2::cr2::MMS_A, tim2::smcr::SMS_A, tim2::smcr::TS_A::ITR0),
+    // Internal trigger connection: RM0377 table 80
+    (TIM21, TIM22): (tim21_tim22, apb2enr, apb2rstr, tim21en, tim22en, tim21rst, tim22rst, tim21::cr2::MMS_A, tim22::smcr::SMS_A, tim22::smcr::TS_A::ITR0),
+
+    // Note: Other combinations would be possible as well, e.g. (TIM21, TIM2) or (TIM2, TIM22).
+    // They can be implemented if needed.
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -237,6 +237,9 @@ pub trait LinkedTimer {
 
     /// Return the current 32 bit counter value.
     fn get_counter(&self) -> u32;
+
+    /// Reset the counter to 0.
+    fn reset(&mut self);
 }
 
 /// A pair of timers that can be linked.
@@ -327,6 +330,18 @@ macro_rules! linked_timers {
                             return (msb << 16) | lsb;
                         }
                     }
+                }
+
+                fn reset(&mut self) {
+                    // Pause
+                    self.tim_primary.cr1.modify(|_, w| w.cen().clear_bit());
+                    self.tim_secondary.cr1.modify(|_, w| w.cen().clear_bit());
+                    // Reset counter
+                    self.tim_primary.cnt.reset();
+                    self.tim_secondary.cnt.reset();
+                    // Continue
+                    self.tim_secondary.cr1.modify(|_, w| w.cen().set_bit());
+                    self.tim_primary.cr1.modify(|_, w| w.cen().set_bit());
                 }
             }
         )+


### PR DESCRIPTION
Implementation of #114.

A `LinkedTimer` impl is initialized with two hardware timers (either TIM2/TIM3 or TIM21/TIM22). The two timers are configured in master/slave mode so that an overflow of the master timer triggers an update on the slave timer. This way, two 16 bit timers can be combined to a single 32 bit timer. (The STM32L0 does not have 32 bit timers.)

![2020-06-29-003656_743x314_scrot](https://user-images.githubusercontent.com/105168/85960039-a7d6ce80-b9a0-11ea-9cad-84567fb68a60.png)

Such a linked timer allows implementing the `Monotonic` trait for the RTIC scheduler with high timer precision.

Right now the implementation does not add logic for detecting an overflow, that is left to the user. Furthermore, no prescaler is configured. And not all possible timer combinations have been implemented.

An example is provided (tested on the STM32L071KBTx). Here's the serial output:

```
Starting example
Init TIM2/TIM3...
Init TIM21/TIM22...
TIM2/TIM3    count   26790878 (msb=408 lsb=52211 Δ26790878 53581 kHz)
TIM21/TIM22  count   11182841 (msb=170 lsb=41743 Δ11182841 22365 kHz)
TIM2/TIM3    count   34790917 (msb=530 lsb=56858 Δ8000039 16000 kHz)
TIM21/TIM22  count   19166170 (msb=292 lsb=29680 Δ7983329 15966 kHz)
TIM2/TIM3    count   42790960 (msb=652 lsb=61509 Δ8000043 16000 kHz)
TIM21/TIM22  count   27166218 (msb=414 lsb=34336 Δ8000048 16000 kHz)
TIM2/TIM3    count   50791003 (msb=775 lsb=624 Δ8000043 16000 kHz)
TIM21/TIM22  count   35132916 (msb=536 lsb=5642 Δ7966698 15933 kHz)
TIM2/TIM3    count   58791046 (msb=897 lsb=5275 Δ8000043 16000 kHz)
...
```

Let me know whether this is useful, and whether the implementation looks correct. This was my first STM32 timer deep-dive, I spent quite a few hours looking through the reference manual to figure out how to link timers :slightly_smiling_face: 

The relevant information in the reference manual (RM0377) is in section 16.3.15 "Timer synchronization". Here's the section that describes timer linking:

![2020-06-29-003857_765x358_scrot](https://user-images.githubusercontent.com/105168/85960066-ec626a00-b9a0-11ea-8415-1c59daaf94e8.png)