### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,51 +78,46 @@ for example the `STM32L062K8Tx` uses the GPIO peripheral version named
 `io-STM32L051`.
 
 
-# Build Dependencies
+# Toolchain Setup
 
-1. Rustup toolchain installer
+In order to use this HAL, you need the following Setup:
 
-    https://rustup.rs
+1. Install Rustup
 
+    See [rustup.rs](https://rustup.rs/) for details. You may als be able to
+    install Rustup directly through your distro.
 
-# Toolchain Configuration
+2. Install the `arm-none-eabi` compiler toolchain
 
-`$ rustup target add thumbv6m-none-eabi`
+	https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
+
+    If you cannot install the toolchain directly through your OS / distro, we
+    recommend installing the precompiled binaries to '/usr/local/opt'.  Add the
+    bin folders (/bin & /arm-none-eabi/bin) to your environments variable 'PATH'.
+
+3. Install the `thumbv6m-none-eabi` target for Rust
+
+    Simply run `rustup target add thumbv6m-none-eabi`
+
+For more instructions on how to get started with ARM / Cortex-M programming
+using Rust, check out the [Embedded Rust
+Book](https://rust-embedded.github.io/book/).
 
 
 # Build Examples
 
-`$ cargo build --release --examples --features stm32l0x1,rt`
+You can build examples through Cargo:
+
+    $ cargo build --release --examples --features stm32l0x1,rt
+
+Note that not all examples are compatible with all MCUs. You might need to peek
+into the example source code.
 
 
-# Dependecies for Flashing
+# Flashing Using Helper Scripts
 
-1. Download and install the arm-none-eabi toolchain
-
-	https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
-	We recommend installing the precompiled binaries to '/usr/local/opt'. 
-	Add the bin folders (/bin & /arm-none-eabi/bin) to your environments variable 'PATH'.
-
-2. Install STLink Tool (>=v1.5.1)
-
-	https://github.com/texane/stlink
-
-3. Install OpenOCD (OPTIONAL)
-
-    NOTE: OpenOCD v0.10.0 does not fully support the stm32l0 family MCU. We recommend using `gnu-mcu-eclipse/openocd` instead:
-
-    https://gnu-mcu-eclipse.github.io/openocd/install/
-    We recommend installing the precompiled binaries to '/usr/local/opt'. 
-	Add the bin folders (i.e. - /usr/local/opt/gnu-mcu-eclipse/openocd/0.10.0-12-20190422-2015/bin) to your environments variable 'PATH'.
-
-4. Install GDB Dashboard (OPTIONAL)
-
-	https://github.com/cyrus-and/gdb-dashboard
-
-
-# Flashing
-
-The following instructions outline how-to on flashing the 'serial' example code. This can be extended to any other example code.
+The following instructions outline how-to on flashing the 'serial' example
+code. This can be extended to any other example code.
 
 ## Flashing with ST-Flash:
 
@@ -139,7 +134,7 @@ The following instructions outline how-to on flashing the 'serial' example code.
     ```
 
 
-# Debugging
+# Debugging Using Helper Scripts
 
 ## Debugging with GDB
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,78 @@ stm32l0xx-hal
 
 [![Build Status](https://travis-ci.com/stm32-rs/stm32l0xx-hal.svg?branch=master)](https://travis-ci.com/stm32-rs/stm32l0xx-hal)
 
-[_stm32l0xx-hal_](https://github.com/stm32-rs/stm32l0xx-hal) is a Hardware Abstraction Layer (HAL) for the STMicro STM32L0xx family of microcontrollers.
+[_stm32l0xx-hal_](https://github.com/stm32-rs/stm32l0xx-hal) is a Hardware
+Abstraction Layer (HAL) for the STMicro STM32L0xx family of microcontrollers.
 
-This crate relies on Adam Greig's [stm32l0](https://crates.io/crates/stm32l0) crate to provide appropriate register definitions and implements a partial set of the [embedded-hal](https://github.com/rust-embedded/embedded-hal) traits.
+This crate relies on Adam Greig's [stm32l0](https://crates.io/crates/stm32l0)
+crate to provide appropriate register definitions and implements a partial set
+of the [embedded-hal](https://github.com/rust-embedded/embedded-hal) traits.
 
-Based on the [stm32l1xx-hal](https://github.com/stm32-rs/stm32l1xx-hal) crate by Vitaly Domnikov and the [stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal) crate by Daniel Egger.
+Based on the [stm32l1xx-hal](https://github.com/stm32-rs/stm32l1xx-hal) crate
+by Vitaly Domnikov and the [stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal)
+crate by Daniel Egger.
 
+# Usage
+
+Add the [`stm32l0xx-hal` crate](https://crates.io/crates/stm32l0xx-hal) to your
+dependencies in `Cargo.toml` and make sure to pick the appropriate `mcu-*`
+Cargo feature to enjoy the full feature set for your MCU (see next section
+"Supported Configurations" for more details).
+
+For example, when using the STM32L071KBTx MCU:
+
+```toml
+[dependencies]
+stm32l0xx-hal = { version = "0.6.2", features = ["mcu-STM32L071KBTx", "rt"] }
+```
 
 # Supported Configurations
 
-* __stm32l0x1__
-* __stm32l0x2__
-* __stm32l0x3__
+The STM32L0 family consists of different subfamilies with different peripherals
+and I/O configurations. Superficially, the family can be grouped into the
+groups `stm32l0x1`, `stm32l0x2` and `stm32l0x3`. However, some aspects like
+alternate function mappings for I/O pins do not follow these groups.
+
+In order for the HAL to properly support all those MCUs, we generate some
+peripheral mappings and corresponding Cargo features using
+[cube-parse](https://github.com/dbrgn/cube-parse/).
+
+## MCU Features (`mcu-*`)
+
+The easiest way for you to get started, is to use your appropriate `mcu-*`
+feature. For example, when using the STM32L071KBTx MCU, you just set the
+`mcu-STM32L071KBTx` feature in `Cargo.toml`:
+
+```toml
+# Cargo.toml
+[dependencies]
+stm32l0xx-hal = { version = "0.6.2", features = ["mcu-STM32L071KBTx", "rt"] }
+```
+
+If you take a look at the [`Cargo.toml`
+file](https://github.com/stm32-rs/stm32l0xx-hal/blob/master/Cargo.toml), you
+can see that `mcu-STM32L071KBTx` is just an alias for `["io-STM32L071",
+"stm32l0x1", "lqfp32"]`.
+
+## I/O Features (`io-*`)
+
+The `io-*` features are based on the GPIO peripheral version. This determines
+the pin function mapping of the MCU. The features seem to correspond to the
+product categories.
+
+Right now, the following features are supported:
+
+- `io-STM32L021` (Product category 1)
+- `io-STM32L031` (Product category 2)
+- `io-STM32L051` (Product category 3)
+- `io-STM32L071` (Product category 5)
+
+The product categories should be listed in your MCU family datasheet. The name
+of the `io-*` feature itself is derived from the internal name used in the
+STM32CubeMX database. It does not necessarily match the name of the MCU,
+for example the `STM32L062K8Tx` uses the GPIO peripheral version named
+`io-STM32L051`.
+
 
 # Build Dependencies
 
@@ -27,21 +87,11 @@ Based on the [stm32l1xx-hal](https://github.com/stm32-rs/stm32l1xx-hal) crate by
 
 `$ rustup target add thumbv6m-none-eabi`
 
+
 # Build Examples
 
 `$ cargo build --release --examples --features stm32l0x1,rt`
 
-# Using as a Dependency
-
-To use the stm32l0xx-hal [crate](https://crates.io/crates/stm32l0xx-hal) as a dependency, add the following definition to your `Cargo.toml`:
-
-``` 
-[dependencies.stm32l0xx-hal]
-version = "0.6.2"
-features = ["stm32l0x1", "rt"]
-```
-
-Example Projects: [HABEXpico](https://github.com/arkorobotics/HABEXpico/tree/master/Firmware)
 
 # Dependecies for Flashing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Based on the [stm32l1xx-hal](https://github.com/stm32-rs/stm32l1xx-hal) crate
 by Vitaly Domnikov and the [stm32f4xx-hal](https://github.com/stm32-rs/stm32f4xx-hal)
 crate by Daniel Egger.
 
+
 # Usage
 
 Add the [`stm32l0xx-hal` crate](https://crates.io/crates/stm32l0xx-hal) to your
@@ -27,6 +28,7 @@ For example, when using the STM32L071KBTx MCU:
 [dependencies]
 stm32l0xx-hal = { version = "0.6.2", features = ["mcu-STM32L071KBTx", "rt"] }
 ```
+
 
 # Supported Configurations
 
@@ -117,6 +119,7 @@ for example the `STM32L062K8Tx` uses the GPIO peripheral version named
 
 	https://github.com/cyrus-and/gdb-dashboard
 
+
 # Flashing
 
 The following instructions outline how-to on flashing the 'serial' example code. This can be extended to any other example code.
@@ -134,6 +137,7 @@ The following instructions outline how-to on flashing the 'serial' example code.
     ``` 
     $ ./openocd_flash.sh target/thumbv6m-none-eabi/release/examples/serial
     ```
+
 
 # Debugging
 
@@ -166,12 +170,13 @@ The following instructions outline how-to on flashing the 'serial' example code.
     >>> dashboard -output /dev/ttys001
     ```
 
-Contibutor Notes
----------
 
-- Revert local dependencies to external cargo and uncomment configurations before committing
+# Contibutor Notes
 
-License
--------
+- Revert local dependencies to external cargo and uncomment configurations
+  before committing
+
+
+# License
 
 0-Clause BSD License, see [LICENSE-0BSD.txt](LICENSE-0BSD.txt) for more details.


### PR DESCRIPTION
A lot of people had troubles with using this HAL because the Cargo features were not set up properly. For example:

- https://github.com/stm32-rs/stm32l0xx-hal/issues/118
- https://github.com/stm32-rs/stm32l0xx-hal/issues/103

These features were inadequately documented. The first commit of this PR attempts to fix that by documenting how to properly specify a dependency on `stm32l0xx-hal` (and the available Cargo features).

Additionally, I simplified the toolchain setup docs. The repo still contains helper scripts for flashing and debugging. These scripts are highly dependent on your debug probe (JLink? STLink? Something else?), your toolchain (OpenOCD? JLinkExe? The STLink tool? Cargo Flash?), your OS and your MCU. I do not think they should belong in this repo. Documentation on different setups should probably be moved to the Embedded Rust book. My suggestion would be to remove the helper scripts and the corresponding sections in the README (the README updated by this PR already contains a link to the Embedded Rust book).

If there's a toolchain we should recommend, then in my opinion it should be cargo-flash or cargo-embed (as soon as GDB debugging works reliably). Shoutout to @yatekii @Tiwalun @adamgreig and many others that are working on the probe-rs project.

What do you think, @arkorobotics?