### PR TITLE
Removed config tests that prevented stm32l0x1 dfevices from using ADC with DMA

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -337,7 +337,7 @@ pub struct Channels {
 
 impl Channels {
     pub fn new() -> Channels {
-        Channels{flags: 0}
+        Channels { flags: 0 }
     }
 
     /// Adds a channel to the collection

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,13 +1,11 @@
 //! # Analog to Digital converter
 
-#[cfg(feature = "stm32l0x2")]
 use core::{
     ops::DerefMut,
     pin::Pin,
     sync::atomic::{compiler_fence, Ordering},
 };
 
-#[cfg(feature = "stm32l0x2")]
 use as_slice::AsMutSlice;
 
 use crate::{
@@ -17,7 +15,6 @@ use crate::{
     rcc::Rcc,
 };
 
-#[cfg(feature = "stm32l0x2")]
 use crate::dma::{self, Buffer as _};
 
 pub trait AdcExt {
@@ -146,7 +143,6 @@ impl Adc<Ready> {
     /// # Panics
     ///
     /// Panics, if `buffer` is larger than 65535.
-    #[cfg(feature = "stm32l0x2")]
     pub fn start<DmaChan, Buf>(
         mut self,
         channels: impl Into<Channels>,
@@ -218,7 +214,6 @@ impl Adc<Ready> {
     }
 }
 
-#[cfg(feature = "stm32l0x2")]
 impl<DmaChan, Buffer> Adc<Active<DmaChan, Buffer>>
 where
     DmaChan: dma::Channel,
@@ -328,7 +323,6 @@ where
 pub struct Ready;
 
 /// Indicates that the ADC peripheral is performing conversions
-#[cfg(feature = "stm32l0x2")]
 pub struct Active<DmaChan, Buf> {
     transfer: dma::Transfer<DmaToken, DmaChan, Buf, dma::Started>,
     buffer: Buffer,
@@ -342,6 +336,10 @@ pub struct Channels {
 }
 
 impl Channels {
+    pub fn new() -> Channels {
+        Channels{flags: 0}
+    }
+
     /// Adds a channel to the collection
     pub fn add<C>(&mut self, _: C)
     where
@@ -397,7 +395,6 @@ pub enum Trigger {
 ///
 /// Since the DMA transfer takes ownership of the buffer, we need to access it
 /// with unsafe means. This struct is a safe wrapper around this unsafe access.
-#[cfg(feature = "stm32l0x2")]
 struct Buffer {
     ptr: *const u16,
     len: u16,
@@ -414,7 +411,6 @@ struct Buffer {
     r_gt_w: bool,
 }
 
-#[cfg(feature = "stm32l0x2")]
 impl Buffer {
     fn read<T, C, B>(
         &mut self,
@@ -569,13 +565,11 @@ struct TransferState {
 }
 
 /// Iterator over buffered ADC values
-#[cfg(feature = "stm32l0x2")]
 pub struct ReadAvailable<'r, T, C, B> {
     buffer: &'r mut Buffer,
     transfer: &'r dma::Transfer<T, C, B, dma::Started>,
 }
 
-#[cfg(feature = "stm32l0x2")]
 impl<T, C, B> Iterator for ReadAvailable<'_, T, C, B>
 where
     C: dma::Channel,


### PR DESCRIPTION
This is a supported configuration and I've tested it with a NUCLEO-L011K development
board and confirmed in the spec sheet that this is supported

Proposed improvement for  #123