### PR TITLE
fix improper reporting of DMA overruns when remaining bytes is outside the expected range

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -482,7 +482,7 @@ impl Buffer {
 
         // Let's translate what we got from the DMA peripheral into a write
         // position that we can compare with our read position.
-        let pos = self.len - remaining;
+        let pos = self.len.saturating_sub(remaining) % self.len;
 
         TransferState {
             pos,

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -482,7 +482,9 @@ impl Buffer {
 
         // Let's translate what we got from the DMA peripheral into a write
         // position that we can compare with our read position.
-        let pos = self.len.saturating_sub(remaining) % self.len;
+        // Zero can be witnessed in remaining before the DMA reloads
+        // the register so we wrap the result of the subtraction around
+        let pos = (self.len - remaining) % self.len;
 
         TransferState {
             pos,


### PR DESCRIPTION
I've witnessed zeros as well as values larger than the initial setting,
albeit spuriously. Added a saturating subtraction and a modulo to the
position calculation and overrun now seems to be working correctly

There still seems to be more overruns than should strictly be happening,
but I've been unable to pin them down and they disappear when clocking
low enough. They might even be real but it is difficult to know. But
this fix is solid

Fix for #125