### PR TITLE
fix Pin::into_pull_down_input

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -356,7 +356,7 @@ macro_rules! gpio {
                     pub fn into_pull_down_input(
                         mut self,
                     ) -> $PXi<Input<PullDown>> {
-                        self.mode::<Input<Floating>>();
+                        self.mode::<Input<PullDown>>();
                         $PXi {
                             _mode: PhantomData
                         }


### PR DESCRIPTION
There was a typo there... Configuring a Pin as pull-down would actually set it as a floating input.