### PR TITLE
Add MCO support

### DIFF
--- a/examples/mco.rs
+++ b/examples/mco.rs
@@ -1,0 +1,40 @@
+//! Configure the MCO (Microcontroller Clock Output) to give a 2MHz signal on PA8 and PA9, sourced
+//! from the internal HSI16 16MHz oscillator.
+
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    pac::{
+        self,
+        rcc::cfgr::{MCOPRE_A, MCOSEL_A},
+    },
+    prelude::*,
+    rcc::Config,
+};
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Configure the 16MHz internal clock
+    let mut rcc = dp.RCC.freeze(Config::hsi16());
+
+    let gpioa = dp.GPIOA.split(&mut rcc);
+
+    // Source MCO from HSI16, configure prescaler to divide by 8 to get 2MHz output.
+    rcc.configure_mco(MCOSEL_A::HSI16, MCOPRE_A::DIV8, (gpioa.pa8, gpioa.pa9));
+
+    // Individual pins can also be set by passing them directly:
+    // rcc.enable_mco(MCOSEL_A::HSI16, MCOPRE_A::DIV8, gpioa.pa8);
+
+    // Or for larger devices, all 3 MCO pins can be configured:
+    // rcc.configure_mco(MCOSEL_A::HSI16, MCOPRE_A::DIV8, (gpioa.pa8, gpioa.pa9, gpiob.pb13));
+
+    // Probe PA8 or PA9 to see generated 2MHz MCO signal.
+    loop {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod gpio;
 ))]
 pub mod i2c;
 pub mod lptim;
+pub mod mco;
 pub mod prelude;
 pub mod pwm;
 pub mod pwr;

--- a/src/mco.rs
+++ b/src/mco.rs
@@ -1,0 +1,52 @@
+//! MCO (Microcontroller Clock Output)
+//!
+//! MCO is available on PA8 or PA9. See "Table 16. Alternate function port A" in the datasheet.
+
+use crate::gpio::{gpioa, gpiob, AltMode, Analog};
+
+pub trait Pin {
+    fn into_mco(self);
+}
+
+impl Pin for gpioa::PA8<Analog> {
+    fn into_mco(self) {
+        self.set_alt_mode(AltMode::AF0);
+    }
+}
+
+impl Pin for gpioa::PA9<Analog> {
+    fn into_mco(self) {
+        self.set_alt_mode(AltMode::AF0);
+    }
+}
+
+impl Pin for gpiob::PB13<Analog> {
+    fn into_mco(self) {
+        self.set_alt_mode(AltMode::AF2);
+    }
+}
+
+// Blanket impls to allow configuration of all MCO pins.
+impl<P1, P2> Pin for (P1, P2)
+where
+    P1: Pin,
+    P2: Pin,
+{
+    fn into_mco(self) {
+        self.0.into_mco();
+        self.1.into_mco();
+    }
+}
+
+impl<P1, P2, P3> Pin for (P1, P2, P3)
+where
+    P1: Pin,
+    P2: Pin,
+    P3: Pin,
+{
+    fn into_mco(self) {
+        self.0.into_mco();
+        self.1.into_mco();
+        self.2.into_mco();
+    }
+}


### PR DESCRIPTION
I've added MCO (Microcontroller Clock Output) support in a hopefully sensible and typesafe way.

I'm reasonably happy with the impl, but will happily take any improvements. I tested the example with my L053 Nucleo using HSI16 as the clock reference. I can get PA8 and/or PA9 to show a nice steady 2MHz, so the code seems to be working as expected.

MCO consumes the output pin, which I think the API reflects. I'm also assuming MCO is available on all variants, so nothing is feature gated in this PR.