### PR TITLE
Add encoder input support for TIM2 and TIM21

### DIFF
--- a/examples/timer_encoder.rs
+++ b/examples/timer_encoder.rs
@@ -1,0 +1,39 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    encoder::{Mode, Status},
+    pac,
+    prelude::*,
+    rcc::Config,
+};
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Configure the clock.
+    let mut rcc = dp.RCC.freeze(Config::hsi16());
+
+    let gpiob = dp.GPIOB.split(&mut rcc);
+
+    // Create an encoder instance that counts between 0 and 64 using inputs on PB13 and PB14.
+    let mut encoder = dp
+        .TIM21
+        .encoder((gpiob.pb13, gpiob.pb14), Mode::Qei, 64, &mut rcc);
+
+    loop {
+        #[allow(unused)]
+        let Status {
+            count,
+            did_overflow,
+            direction,
+        } = encoder.status();
+
+        // Use encoder state here
+    }
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,0 +1,233 @@
+//! Encoder input using timers.
+
+use crate::gpio::{gpioa, gpiob, AltMode, Analog};
+use crate::pac::{tim2, tim21, TIM2, TIM21};
+use crate::rcc::Rcc;
+use core::marker::PhantomData;
+
+pub trait Pins<TIM> {
+    fn into_alt_mode(self);
+}
+
+pub trait PinCh1<TIM> {
+    fn into_alt_mode(self);
+}
+pub trait PinCh2<TIM> {
+    fn into_alt_mode(self);
+}
+
+impl PinCh1<TIM21> for gpiob::PB13<Analog> {
+    fn into_alt_mode(self) {
+        self.set_alt_mode(AltMode::AF6);
+    }
+}
+impl PinCh2<TIM21> for gpiob::PB14<Analog> {
+    fn into_alt_mode(self) {
+        self.set_alt_mode(AltMode::AF6);
+    }
+}
+
+impl PinCh1<TIM2> for gpioa::PA0<Analog> {
+    fn into_alt_mode(self) {
+        self.set_alt_mode(AltMode::AF2);
+    }
+}
+impl PinCh2<TIM2> for gpioa::PA1<Analog> {
+    fn into_alt_mode(self) {
+        self.set_alt_mode(AltMode::AF2);
+    }
+}
+
+impl<TIM, CH1, CH2> Pins<TIM> for (CH1, CH2)
+where
+    CH1: PinCh1<TIM>,
+    CH2: PinCh2<TIM>,
+{
+    fn into_alt_mode(self) {
+        self.0.into_alt_mode();
+        self.1.into_alt_mode();
+    }
+}
+
+/// Encoder direction.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum Direction {
+    /// Encoder is counting up.
+    Up,
+    /// Encoder is counting down.
+    Down,
+}
+
+/// Encoder status.
+pub struct Status {
+    /// Encoder direction.
+    pub direction: Direction,
+    /// Overflow flag.
+    pub did_overflow: bool,
+    /// Current encoder count.
+    pub count: u16,
+}
+
+/// Encoder mode. See `TIMx_SMCR.SMS` item in datasheet.
+pub enum Mode {
+    /// Encoder mode 1 - Counter counts up/down on TI2FP1 edge depending on TI1FP2 level.
+    CountTi2 = 0b001,
+    /// Encoder mode 2 - Counter counts up/down on TI1FP2 edge depending on TI2FP1 level.
+    CountTi1 = 0b010,
+    ///  Encoder mode 3 (AKA quadrature mode) - Counter counts up/down on both TI1FP1 and TI2FP2 edges depending on the level of the other input.
+    Qei = 0b011,
+}
+
+pub trait EncoderExt<TIM> {
+    fn encoder<PINS>(self, pins: PINS, mode: Mode, arr: u16, rcc: &mut Rcc) -> Encoder<TIM, PINS>
+    where
+        PINS: Pins<TIM>;
+}
+
+pub struct Encoder<T, PINS> {
+    timer: T,
+    _pins: PhantomData<PINS>,
+}
+
+macro_rules! encoders {
+    ($($TIM:ident: ($timXen:ident, $timXrst:ident, $apbXenr:ident, $apbXrstr:ident, $sms:ty),)+) => {
+        $(
+            impl EncoderExt<$TIM> for $TIM {
+                fn encoder<PINS>(
+                    self,
+                    pins: PINS,
+                    mode: Mode,
+                    arr: u16,
+                    rcc: &mut Rcc,
+                ) -> Encoder<$TIM, PINS>
+                where
+                    PINS: Pins<$TIM>,
+                {
+                    Encoder::<$TIM, PINS>::new(self, pins, mode, arr, rcc)
+                }
+            }
+
+            impl<PINS> Encoder<$TIM, PINS>
+            where
+                PINS: Pins<$TIM>,
+            {
+                fn new(timer: $TIM, pins: PINS, mode: Mode, arr: u16, rcc: &mut Rcc) -> Self {
+                    // Enable peripheral, reset it
+                    rcc.rb.$apbXenr.modify(|_, w| w.$timXen().set_bit());
+                    rcc.rb.$apbXrstr.modify(|_, w| w.$timXrst().set_bit());
+                    rcc.rb.$apbXrstr.modify(|_, w| w.$timXrst().clear_bit());
+
+                    // Disable the timer for configuration
+                    timer.cr1.write(|w| w.cen().clear_bit());
+
+                    // Configure encoder inputs.
+                    pins.into_alt_mode();
+
+                    // Encoder mode, count on all edges
+                    timer.smcr.write(|w| {
+                        w
+                            // Trigger source - TI1 edge detector
+                            .ts()
+                            .ti1f_ed()
+                            // Count edges on TI1, direction set by TI2
+                            .sms()
+                            .variant(match mode {
+                                Mode::CountTi1 => <$sms>::ENCODER_MODE_1,
+                                Mode::CountTi2 => <$sms>::ENCODER_MODE_2,
+                                Mode::Qei => <$sms>::ENCODER_MODE_3,
+                            })
+                    });
+
+                    timer.cr1.write(|w| {
+                        w
+                            // Only interrupt on over/underflow (as well as input pulses)
+                            .urs()
+                            .set_bit()
+                            // Enable timer
+                            .cen()
+                            .set_bit()
+                    });
+
+                    // "After setting the ENABLE bit, a delay of two counter clock is needed before the LPTIM is
+                    // actually enabled."
+                    // The slowest LPTIM clock source is LSE at 32768 Hz, the fastest CPU clock is ~80 MHz. At
+                    // these conditions, one cycle of the LPTIM clock takes 2500 CPU cycles, so sleep for 5000.
+                    cortex_m::asm::delay(5000);
+
+                    let mut self_ = Self {
+                        timer,
+                        _pins: PhantomData,
+                    };
+
+                    self_.set_arr(arr);
+
+                    self_
+                }
+
+                /// Get the ARR (Auto Reload Register) value.
+                pub fn arr(&mut self) -> u16 {
+                    self.timer.arr.read().bits() as u16
+                }
+
+                /// Set ARR (Auto Reload Register) value.
+                ///
+                /// ARR may only be set when timer is enabled.
+                pub fn set_arr(&mut self, arr: u16) {
+                    // This is only unsafe for some timers, so we need this to suppress the
+                    // warnings.
+                    #[allow(unused_unsafe)]
+                    self.timer.arr.write(|w| unsafe { w.arr().bits(arr) });
+                }
+
+                /// Listen for over/underflow interrupts
+                pub fn listen(&mut self) {
+                    // Listen for over/underflow.
+                    self.timer.dier.write(|w| w.uie().enabled());
+                }
+
+                /// Listen for over/underflow interrupts, as well as IO triggers.
+                pub fn listen_all(&mut self) {
+                    // Listen for over/underflow.
+                    self.listen();
+
+                    // Listen for counter change as well.
+                    self.timer.dier.write(|w| w.tie().enabled());
+                }
+
+                /// Get the current encoder status.
+                ///
+                /// Note that calling `clear_irq` before this method will clear the `did_overflow` flag.
+                pub fn status(&mut self) -> Status {
+                    // Up = 0, down = 1
+                    let is_dir_up = self.timer.cr1.read().dir().bit_is_clear();
+
+                    // UIF is bit 0
+                    let did_overflow = self.timer.sr.read().bits() & 0x01 == 1;
+
+                    let count = self.timer.cnt.read().bits() as u16;
+
+                    let direction = match is_dir_up {
+                        true => Direction::Up,
+                        false => Direction::Down,
+                    };
+
+                    Status {
+                        did_overflow,
+                        count,
+                        direction,
+                    }
+                }
+
+                /// Clear all interrupts
+                pub fn clear_irq(&mut self) {
+                    self.timer.sr.reset();
+                }
+            }
+        )+
+    }
+}
+
+encoders! {
+    TIM2: (tim2en, tim2rst, apb1enr, apb1rstr, tim2::smcr::SMS_A),
+    TIM21: (tim21en, tim21rst, apb2enr, apb2rstr, tim21::smcr::SMS_A),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod aes;
 pub mod calibration;
 pub mod delay;
 pub mod dma;
+pub mod encoder;
 pub mod exti;
 #[cfg(any(
     feature = "eeprom-128",

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@ pub use embedded_hal::{
 pub use crate::{
     adc::AdcExt as _,
     delay::DelayExt as _,
+    encoder::{EncoderExt, PinCh1, PinCh2, Pins},
     gpio::GpioExt as _,
     pwr::PowerMode as _,
     rcc::RccExt as _,


### PR DESCRIPTION
Adds encoder (QEI) input support to TIM2 and TIM21. I've tested the interrupt handling with an RTIC 0.6 project, and have included a short non-RTIC example to get users off the ground.

This leaves a few pin combinations and a few timers without an implementation currently, as I have no way to test them (or couldn't get them working) - I'll leave that as a job for other people who need it :)