### PR TITLE
Add `Timer::new` to create timer without starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ forget to update the links at the bottom of the changelog as well.-->
 
 ### Additions
 
+- Add `Timer::new` to create timer without starting #152
+
 ### Breaking Changes
+
+- Add `enable` to `GeneralPurposeTimer`
 
 ### Non-Breaking Changes
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -81,10 +81,13 @@ impl TimerExt<SYST> for SYST {
 
 impl Periodic for Timer<SYST> {}
 
+/// Trait for general purpose timer peripherals
 pub trait GeneralPurposeTimer {
     type MasterMode;
 
+    /// Enables the timer peripheral with the peripheral bus
     fn enable(&mut self, rcc: &mut Rcc);
+    /// Selects the master mode for this timer
     fn select_master_mode(&mut self, variant: Self::MasterMode);
 }
 


### PR DESCRIPTION
Useful for initializing a `Timer` to call `start()` on later.

I suppose `timer()` creates it _and_ starts it as a sort of convenience, but it's a little silly having to pass a dummy timeout. More seriously, calling `timer()` with a dummy timeout but without `listen()` and later calling `listen()` and `start()` can cause a subtle issue, I believe. If the dummy timeout has already overflowed, the interrupt is already pending and will immediately fire, before the new `start` has expired (necessitating a `clear_irq()` call in addition to `listen` and `start`).

This PR doesn't fix that issue per se, it only avoids it for creation but I think the expected behavior for `start()` would be that it also calls `clear_irq`, WDYT?

This is a breaking change for the `GeneralPurposeTimer` trait but it feels reasonable, though we could also add an additional trait to hold `enable`.