### PR TITLE
Allow skipping linker script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,11 +21,11 @@ fn main() {
         feature_count += 1;
     }
 
-    if feature_count != 1 {
-        panic!("\n\nMust select exactly one package for linker script generation!\nChoices: 'stm32l0x1' or 'stm32l0x2' or 'stm32l0x3'\nAlternatively, pick the mcu-feature that matches your MCU, for example 'mcu-STM32L071KBTx'\n\n");
-    }
-
     if !cfg!(feature = "disable-linker-script") {
+        if feature_count != 1 {
+            panic!("\n\nMust select exactly one package for linker script generation!\nChoices: 'stm32l0x1' or 'stm32l0x2' or 'stm32l0x3'\nAlternatively, pick the mcu-feature that matches your MCU, for example 'mcu-STM32L071KBTx'\n\n");
+        }
+
         let linker = if cfg!(feature = "stm32l0x1") {
             include_bytes!("memory_l0x1.x").as_ref()
         } else if cfg!(feature = "stm32l0x2") {


### PR DESCRIPTION
By counting the features before the "disable-linker-script" feature is checked, it will fail even if this flag was set.