### PR TITLE
Fixed bad op for RTC wakeup

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -471,7 +471,7 @@ impl timer::CountDown for WakeupTimer<'_> {
         T: Into<Self::Time>,
     {
         let delay = delay.into();
-        assert!((1..=2 ^ 17).contains(&delay));
+        assert!((1..=0x1_FF_FF).contains(&delay));
 
         let delay = delay - 1;
 


### PR DESCRIPTION
`^` was probably intended as "power" but is XOR in this context, limiting delay to a maximum of 2 XOR 17, or ..=19