### PR TITLE
added support for Device electronic signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod rtc;
     feature = "io-STM32L071",
 ))]
 pub mod serial;
+pub mod signature;
 pub mod spi;
 pub mod syscfg;
 pub mod time;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -3,30 +3,37 @@
 //! The STM32L0 contains a few read-only registers with factory programming
 //! data that are written during production.
 
-
 use cortex_m::interrupt;
 
 mod pointers {
-    pub const DEVICE_ID_PTR: *const u8 = 0x1FF8_0050 as _;
+    pub const FACTORY_PROD_PTR: *const u8 = 0x1FF8_0050 as _;
+    pub const UNIQUE_ID_PTR: *const u8 = 0x1FF8_0064 as _;
     pub const FLASH_SIZE_PTR: *const u16 = 0x1FF8_007C as _;
 }
 
 use pointers::*;
 
 /// Returns a 12-byte unique device ID
-pub fn device_id() -> &'static [u8; 12] {
-    unsafe { &*DEVICE_ID_PTR.cast::<[u8; 12]>() }
+/// According to the Reference Manual, the device electronic
+/// signature is non-contiguous. This wrapper makes it contiguous
+/// since the unicity is only given by all of those fields.
+pub fn device_id(buffer: &mut [u8; 12]) {
+    unsafe {
+        buffer[0..8].copy_from_slice(&*(FACTORY_PROD_PTR).cast::<[u8; 8]>());
+        buffer[8..12].copy_from_slice(&*(UNIQUE_ID_PTR).cast::<[u8; 4]>());
+    }
 }
 
 /// Returns a string with a hex-encoded unique device ID
 pub fn device_id_hex() -> &'static str {
     static mut DEVICE_ID_STR: [u8; 24] = [0; 24];
-
+    let mut buffer: [u8; 12] = [0; 12];
+    device_id(&mut buffer);
     unsafe {
         if DEVICE_ID_STR.as_ptr().read_volatile() == 0 {
             interrupt::free(|_| {
                 let hex = b"0123456789abcdef";
-                for (i, b) in device_id().iter().enumerate() {
+                for (i, b) in buffer.iter().enumerate() {
                     let lo = b & 0xf;
                     let hi = (b >> 4) & 0xfu8;
                     DEVICE_ID_STR[i * 2] = hex[hi as usize];

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -30,8 +30,8 @@ pub fn device_id_hex() -> &'static str {
                 for (i, b) in device_id().iter().enumerate() {
                     let lo = b & 0xf;
                     let hi = (b >> 4) & 0xfu8;
-                    DEVICE_ID_STR[i*2] = hex[hi as usize];
-                    DEVICE_ID_STR[i*2+1] = hex[lo as usize];
+                    DEVICE_ID_STR[i * 2] = hex[hi as usize];
+                    DEVICE_ID_STR[i * 2 + 1] = hex[lo as usize];
                 }
             });
         }
@@ -39,7 +39,6 @@ pub fn device_id_hex() -> &'static str {
         core::str::from_utf8_unchecked(&DEVICE_ID_STR)
     }
 }
-
 
 /// Returns the Flash memory size of the device in Kbytes
 pub fn flash_size_kb() -> u16 {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -3,7 +3,6 @@
 //! The STM32L0 contains a few read-only registers with factory programming
 //! data that are written during production.
 
-#![no_std]
 
 use cortex_m::interrupt;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,47 @@
+//! Factory-programmed data
+//!
+//! The STM32L0 contains a few read-only registers with factory programming
+//! data that are written during production.
+
+#![no_std]
+
+use cortex_m::interrupt;
+
+mod pointers {
+    pub const DEVICE_ID_PTR: *const u8 = 0x1FF8_0050 as _;
+    pub const FLASH_SIZE_PTR: *const u16 = 0x1FF8_007C as _;
+}
+
+use pointers::*;
+
+/// Returns a 12-byte unique device ID
+pub fn device_id() -> &'static [u8; 12] {
+    unsafe { &*DEVICE_ID_PTR.cast::<[u8; 12]>() }
+}
+
+/// Returns a string with a hex-encoded unique device ID
+pub fn device_id_hex() -> &'static str {
+    static mut DEVICE_ID_STR: [u8; 24] = [0; 24];
+
+    unsafe {
+        if DEVICE_ID_STR.as_ptr().read_volatile() == 0 {
+            interrupt::free(|_| {
+                let hex = b"0123456789abcdef";
+                for (i, b) in device_id().iter().enumerate() {
+                    let lo = b & 0xf;
+                    let hi = (b >> 4) & 0xfu8;
+                    DEVICE_ID_STR[i*2] = hex[hi as usize];
+                    DEVICE_ID_STR[i*2+1] = hex[lo as usize];
+                }
+            });
+        }
+
+        core::str::from_utf8_unchecked(&DEVICE_ID_STR)
+    }
+}
+
+
+/// Returns the Flash memory size of the device in Kbytes
+pub fn flash_size_kb() -> u16 {
+    unsafe { *FLASH_SIZE_PTR }
+}


### PR DESCRIPTION
this was talked briefely in #120, i think @hannobraun 's idea is also the easiest to add.

code was indeed copied from [stm-32-device-signature](https://github.com/stm32-rs/stm32-device-signature/blob/master/src/lib.rs), credit to @Disasm 