### PR TITLE
Add parapgraph about flash memory size in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Currently a default Flash and RAM size are configured depending on the chip's su
 | `stm32l0x3` | 64kB       | 8kB      |
 
 However not all chips in the subfamily have the same flash and RAM size. Due to a known limitation
-to the scripts used to generate the features the sizes might not correspond to the true sizes of 
-the MCU. You should double check with the datasheet to make sure the flash and RAM sizes are correct.
+to the scripts used to generate the features, the sizes might not correspond to the true sizes of 
+the MCU. You should double check with the datasheet, to make sure the flash and RAM sizes are correct.
 
 If they are not correct, you can override the `memory.x` of `stm32l0xx-hal` by providing your own.
 In your crate root, add a file called `memory.x` with the correct configuration. For example:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,63 @@ STM32CubeMX database. It does not necessarily match the name of the MCU,
 for example the `STM32L062K8Tx` uses the GPIO peripheral version named
 `io-STM32L051`.
 
+## Flash memory
+
+Currently a default Flash and RAM size are configured depending on the chip's subfamily.
+
+| Chip        | Flash size | RAM size |
+| ----------- | ---------- | -------- |
+| `stm32l0x1` | 16kB       | 2kB      |
+| `stm32l0x2` | 192kB      | 20kB     |
+| `stm32l0x3` | 64kB       | 8kB      |
+
+However not all chips in the subfamily have the same flash and RAM size. Due to a known limitation
+to the scripts used to generate the features the sizes might not correspond to the true sizes of 
+the MCU. You should double check with the datasheet to make sure the flash and RAM sizes are correct.
+
+If they are not correct, you can override the `memory.x` of `stm32l0xx-hal` by providing your own.
+In your crate root, add a file called `memory.x` with the correct configuration. For example:
+
+```
+MEMORY
+{
+  FLASH : ORIGIN = 0x08000000, LENGTH = 64K
+  RAM : ORIGIN = 0x20000000, LENGTH = 8K
+}
+```
+
+Add a `build.rs` file with the following content:
+
+```rust
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=memory.x");
+}
+```
+
+And finally add the `disable-linker-script` feature to your `stm32l0xx-hal` dependency:
+
+```toml
+# Cargo.toml
+[dependencies]
+stm32l0xx-hal = { version = "0.7.0", features = ["mcu-STM32L071K8Ux", "disable-linker-script"] }
+```
+
+For more information, see: https://github.com/stm32-rs/stm32l0xx-hal/issues/170
+
 
 # Toolchain Setup
 


### PR DESCRIPTION
Following #170 

Until a better 'fix' is available, this adds a paragraph in the readme to explain how to override the memory configuration.

It is a bit on the long side, I preferred to be complete but if it is too long I can cut down some parts. Let me know if I need to change anything. I did not test this yet, but I copied the memory.x file from here and the build.rs from the one you linked so I expect this to be good. :slightly_smiling_face: 