### PR TITLE
Fix max frequency assertion

### DIFF
--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -340,7 +340,7 @@ impl RccExt for RCC {
                     PLLDiv::Div3 => freq / 3,
                     PLLDiv::Div4 => freq / 4,
                 };
-                assert!(freq <= 32_u32.MHz().0);
+                assert!(freq <= 32_000_000);
 
                 self.cfgr.write(move |w| unsafe {
                     w.pllmul()


### PR DESCRIPTION
IIRC I did test the examples when working on #183, but this error shows
up when using the PLL which none of them do. I found this when testing
with my own project code. At any rate, here's a fix for embedded-time
comparisons when using the PLL.