### PR TITLE
Fixed potential race condition when flushing serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ before this will break the build because of the missing features.
 ### Non-Breaking Changes
 
 ### Fixes
+- Fixed potential race condition when flushing the tx serial buffer.
 
 ### Documentation
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -620,13 +620,12 @@ macro_rules! usart {
                     // NOTE(unsafe) atomic read with no side effects
                     let isr = unsafe { (*$USARTX::ptr()).isr.read() };
 
-                    // Frame complete, set the TC Clear Flag
-                    unsafe {
-                        (*$USARTX::ptr()).icr.write(|w| {w.tccf().set_bit()});
-                    }
-
                     // Check TC bit on ISR
                     if isr.tc().bit_is_set() {
+                        // Frame complete, set the TC Clear Flag
+                        unsafe {
+                            (*$USARTX::ptr()).icr.write(|w| {w.tccf().set_bit()});
+                        }
                         Ok(())
                     } else {
                         Err(nb::Error::WouldBlock)


### PR DESCRIPTION
this addresses #179 where there could be a timing where the TC clear could be done after the read, missing it. would cause deadlock sometimes if flush is used with `nb::block` because the exit condition would be missed.

remarks welcome