### PR TITLE
PXi.downgrade() erases the port identifier as well

### DIFF
--- a/examples/blinky_downgrade.rs
+++ b/examples/blinky_downgrade.rs
@@ -1,0 +1,54 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{
+    gpio::{Output, Pin, PushPull},
+    pac,
+    prelude::*,
+    rcc::Config,
+};
+
+struct Matrix {
+    leds: [Pin<Output<PushPull>>; 1],
+}
+
+// This example utilizes downgraded pins, to store different pin
+// types together in an array. This is useful for building things like
+// led matrices, or key scan matrices, etc.
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Configure the clock.
+    let mut rcc = dp.RCC.freeze(Config::hsi16());
+
+    // Acquire the GPIOA peripheral. This also enables the clock for GPIOA in
+    // the RCC register.
+    let gpioa = dp.GPIOA.split(&mut rcc);
+
+    // Configure PA1 as output, using a downgraded Pin which can
+    // be put into an array of different pin types.
+    let mut matrix = Matrix {
+        leds: [gpioa.pa1.into_push_pull_output().downgrade()],
+    };
+
+    loop {
+        // Loop through all the LEDs in the matrix and set them to high
+        for led in matrix.leds.iter_mut() {
+            for _ in 0..250_000 {
+                led.set_high().unwrap();
+            }
+        }
+
+        // Loop through all the LEDs and set them to low
+        for led in matrix.leds.iter_mut() {
+            for _ in 0..250_000 {
+                led.set_low().unwrap();
+            }
+        }
+    }
+}

--- a/examples/button_irq_rtic.rs
+++ b/examples/button_irq_rtic.rs
@@ -17,7 +17,7 @@ use stm32l0xx_hal::{
 #[app(device = stm32l0xx_hal::pac, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: gpiob::PB<Output<PushPull>>,
+        led: Pin<Output<PushPull>>,
         int: Exti,
     }
 

--- a/examples/lptim.rs
+++ b/examples/lptim.rs
@@ -10,7 +10,7 @@ use cortex_m_rt::entry;
 use nb::block;
 use stm32l0xx_hal::{
     exti::{DirectLine, Exti},
-    gpio::{gpiob::PB, Output, PushPull},
+    gpio::{Output, Pin, PushPull},
     lptim::{self, ClockSrc, LpTimer},
     pac,
     prelude::*,
@@ -105,7 +105,7 @@ fn main() -> ! {
     }
 }
 
-fn blink(led: &mut PB<Output<PushPull>>) {
+fn blink(led: &mut Pin<Output<PushPull>>) {
     led.set_high().unwrap();
     delay();
     led.set_low().unwrap();

--- a/examples/pwr.rs
+++ b/examples/pwr.rs
@@ -7,7 +7,7 @@ use cortex_m::{asm, peripheral::NVIC};
 use cortex_m_rt::entry;
 use stm32l0xx_hal::{
     exti::{ConfigurableLine, Exti, TriggerEdge},
-    gpio::{gpiob::PB, Output, PushPull},
+    gpio::{Output, Pin, PushPull},
     pac,
     prelude::*,
     pwr::{self, PWR},
@@ -107,7 +107,7 @@ fn main() -> ! {
     }
 }
 
-fn blink(led: &mut PB<Output<PushPull>>) {
+fn blink(led: &mut Pin<Output<PushPull>>) {
     led.set_high().unwrap();
     delay();
     led.set_low().unwrap();

--- a/examples/timer_interrupt_rtic.rs
+++ b/examples/timer_interrupt_rtic.rs
@@ -11,7 +11,7 @@ use stm32l0xx_hal::{gpio::*, pac, prelude::*, rcc::Config, timer::Timer};
 #[app(device = stm32l0xx_hal::pac, peripherals = true)]
 const APP: () = {
     struct Resources {
-        led: gpioa::PA<Output<PushPull>>,
+        led: Pin<Output<PushPull>>,
         timer: Timer<pac::TIM2>,
     }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -310,17 +310,17 @@ macro_rules! gpio {
                     fn mode<M: PinMode>(&mut self) {
                         let offset = 2 * $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            let _ = &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (u32::from(M::PUPDR) << offset))
                             });
 
                             if let Some(otyper) = M::OTYPER {
-                                &(*$GPIOX::ptr()).otyper.modify(|r, w| {
+                                let _ = &(*$GPIOX::ptr()).otyper.modify(|r, w| {
                                     w.bits(r.bits() & !(0b1 << $i) | (u32::from(otyper) << $i))
                                 });
                             }
 
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            let _ = &(*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (u32::from(M::MODER) << offset))
                             });
                         }
@@ -501,16 +501,16 @@ macro_rules! gpio {
                         let offset2 = 4 * $i;
                         unsafe {
                             if offset2 < 32 {
-                                &(*$GPIOX::ptr()).afrl.modify(|r, w| {
+                                let _ = &(*$GPIOX::ptr()).afrl.modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             } else {
                                 let offset2 = offset2 - 32;
-                                &(*$GPIOX::ptr()).afrh.modify(|r, w| {
+                                let _ = &(*$GPIOX::ptr()).afrh.modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             }
-                            &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            let _ = &(*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                             });
                         }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -310,17 +310,17 @@ macro_rules! gpio {
                     fn mode<M: PinMode>(&mut self) {
                         let offset = 2 * $i;
                         unsafe {
-                            let _ = &(*$GPIOX::ptr()).pupdr.modify(|r, w| {
+                            (*$GPIOX::ptr()).pupdr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (u32::from(M::PUPDR) << offset))
                             });
 
                             if let Some(otyper) = M::OTYPER {
-                                let _ = &(*$GPIOX::ptr()).otyper.modify(|r, w| {
+                                (*$GPIOX::ptr()).otyper.modify(|r, w| {
                                     w.bits(r.bits() & !(0b1 << $i) | (u32::from(otyper) << $i))
                                 });
                             }
 
-                            let _ = &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (u32::from(M::MODER) << offset))
                             });
                         }
@@ -501,16 +501,16 @@ macro_rules! gpio {
                         let offset2 = 4 * $i;
                         unsafe {
                             if offset2 < 32 {
-                                let _ = &(*$GPIOX::ptr()).afrl.modify(|r, w| {
+                                (*$GPIOX::ptr()).afrl.modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             } else {
                                 let offset2 = offset2 - 32;
-                                let _ = &(*$GPIOX::ptr()).afrh.modify(|r, w| {
+                                (*$GPIOX::ptr()).afrh.modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             }
-                            let _ = &(*$GPIOX::ptr()).moder.modify(|r, w| {
+                            (*$GPIOX::ptr()).moder.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                             });
                         }


### PR DESCRIPTION
PXi.downgrade() should erase the port identifier, allowing pins to be collected into an array. See full description here: https://github.com/stm32-rs/stm32l0xx-hal/issues/189.

Most of this is borrowed from [stm32f0xx-hal](https://github.com/stm32-rs/stm32f0xx-hal).

Still waiting on my board to arrive, so I can fully test this during board bring-up, but wanted to get the code up early.