### PR TITLE
Cargo.toml cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,21 +2,14 @@
 edition = "2018"
 authors = [
     "Arko <arko2600@gmail.com>",
+    "Hanno Braun <hanno@braun-odw.eu>",
+    "Danilo Bargen <mail@dbrgn.ch>",
 ]
-categories = [
-    "embedded",
-    "hardware-support",
-    "no-std",
-]
+categories = ["embedded", "hardware-support", "no-std"]
 description = "Peripheral access API for STM32L0 series microcontrollers"
 documentation = "https://docs.rs/crate/stm32l0xx-hal"
 
-keywords = [
-    "arm",
-    "cortex-m",
-    "stm32l0xx",
-    "hal",
-]
+keywords = ["arm", "cortex-m", "stm32l0xx", "hal"]
 license = "0BSD"
 name = "stm32l0xx-hal"
 readme = "README.md"
@@ -27,40 +20,26 @@ version = "0.7.0"
 features = ["stm32l0x2", "rt", "stm32-usbd", "eeprom-2048", "rtc"]
 targets = ["thumbv6m-none-eabi"]
 
-
 [dependencies]
-stm32l0 = "0.13.0"
 as-slice = "0.2.1"
+cast = { version = "0.2.2", default-features = false }
 cortex-m =  "0.7.0"
 cortex-m-rt = "0.6.8"
 cortex-m-semihosting = "0.3.2"
-nb = "1.0.0"
+embedded-hal = { version = "0.2.3", features = ["unproven"] }
 embedded-time = "0.12.0"
+nb = "1.0.0"
 rtcc = { version = "0.2", optional = true }
-
-[dependencies.cast]
-version = "0.2.2"
-default-features = false
-
-[dependencies.embedded-hal]
-version = "0.2.3"
-features = ["unproven"]
-
-[dependencies.stm32-usbd]
-version = "0.6.0"
-optional = true
-
-[dependencies.void]
-version = "1.0.2"
-default-features = false
-
+stm32l0 = "0.13.0"
+stm32-usbd = { version = "0.6.0", optional = true }
+void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]
 aligned = "0.3.1"
+cortex-m-rtic = "0.5.6"
 heapless = "0.7.1"
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.1"
-cortex-m-rtic = "0.5.6"
 usb-device = "0.2.3"
 usbd-serial = "0.1.0"
 
@@ -434,4 +413,3 @@ required-features = ["rt", "stm32l0x2", "stm32-usbd"]
 [[example]]
 name = "temperature"
 required-features = ["rt", "stm32l0x2",]
-


### PR DESCRIPTION
- Add all three main committers to authors list
- More compact dependency notation
- Sort dependencies alphabetically