### PR TITLE
Fix Cargo features used by docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/stm32-rs/stm32l0xx-hal"
 version = "0.8.0"
 
 [package.metadata.docs.rs]
-features = ["stm32l0x2", "rt", "stm32-usbd", "eeprom-2048", "rtc"]
+features = ["mcu-STM32L071KBTx", "rt", "stm32-usbd", "rtc"]
 targets = ["thumbv6m-none-eabi"]
 
 [dependencies]


### PR DESCRIPTION
The docs.rs build currently fails: https://docs.rs/crate/stm32l0xx-hal/0.8.0/builds/458082 Some of the required features for building were missing.

To avoid this in the future, specified an MCU feature for a random (read: the one I'm using) concrete MCU instead.

Can we re-trigger the building of the docs without creating a new release? Probably not, right? Should we create a 0.8.1 release to fix the docs? (I could do that.)