### PR TITLE
Make cortex-m-semihosting a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ as-slice = "0.2.1"
 cast = { version = "0.2.2", default-features = false }
 cortex-m =  "0.7.0"
 cortex-m-rt = "0.6.8"
-cortex-m-semihosting = "0.3.2"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 embedded-time = "0.12.0"
 nb = "1.0.0"
@@ -37,6 +36,7 @@ void = { version = "1.0.2", default-features = false }
 [dev-dependencies]
 aligned = "0.3.1"
 cortex-m-rtic = "0.5.6"
+cortex-m-semihosting = "0.3.2"
 heapless = "0.7.1"
 panic-halt = "0.2.0"
 panic-semihosting = "0.5.1"


### PR DESCRIPTION
It's not actually used anywhere except in examples.

(Would be nice if we could get this into the 0.9 release #207 as well.)