### PR TITLE
Fixed missing possible pins for SPI1 for STM32L0x1 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ forget to update the links at the bottom of the changelog as well.-->
 ### Non-Breaking Changes
 
 ### Fixes
+- Add other possible pins for SPI1 for L0x1 family
 
 ### Documentation
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -11,7 +11,6 @@ use embedded_time::rate::Hertz;
 use crate::dma::{self, Buffer};
 
 use crate::gpio::gpioa::*;
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 use crate::gpio::gpiob::*;
 
 use crate::gpio::{AltMode, Analog};
@@ -154,15 +153,20 @@ pins! {
     SPI1:
         SCK: [
             [NoSck, None],
-            [PA5<Analog>, AltMode::AF0]
+            [PA5<Analog>, AltMode::AF0],
+            [PB3<Analog>, AltMode::AF0]
         ]
         MISO: [
             [NoMiso, None],
-            [PA6<Analog>, AltMode::AF0]
+            [PA6<Analog>, AltMode::AF0],
+            [PA11<Analog>, AltMode::AF0],
+            [PB4<Analog>, AltMode::AF0]
         ]
         MOSI: [
             [NoMosi, None],
-            [PA7<Analog>, AltMode::AF0]
+            [PA7<Analog>, AltMode::AF0],
+            [PA12<Analog>, AltMode::AF0],
+            [PB5<Analog>, AltMode::AF0]
         ]
 }
 


### PR DESCRIPTION
This was missing other possible pins for SPI1. there still is some other to be added but i think we should find a better way to have that, kind of like it's done for serial impl...