### PR TITLE
Enable USART DMA for STM32L0x1 family

### DIFF
--- a/examples/serial_dma_async.rs
+++ b/examples/serial_dma_async.rs
@@ -55,9 +55,11 @@ fn main() -> ! {
         .unwrap()
         .split();
 
-    // we only have two elements for each queue, so U2 is fine (size is max 2)
-    let mut rx_buffers: Queue<Pin<DmaBuffer>, 2> = Queue::new();
-    let mut tx_buffers: Queue<Pin<DmaBuffer>, 2> = Queue::new();
+    // we only have two elements for each queue, so size is max 2 is fine.
+    // Note that due to current const generics limitations the queue capacity
+    // is calculated by heapless as N-1, so we declare it as '3-1' elements.
+    let mut rx_buffers: Queue<Pin<DmaBuffer>, 3> = Queue::new();
+    let mut tx_buffers: Queue<Pin<DmaBuffer>, 3> = Queue::new();
 
     // enqueue as many buffers as available into rx_buffers
     unsafe {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -11,19 +11,19 @@ pub use crate::pac::{LPUART1, USART1, USART2, USART4, USART5};
 use crate::rcc::{Enable, Rcc, LSE};
 use embedded_time::rate::{Baud, Extensions};
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
 use core::{
     ops::{Deref, DerefMut},
     pin::Pin,
 };
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
 use as_slice::{AsMutSlice, AsSlice};
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
 pub use crate::dma;
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
 use crate::dma::Buffer;
 
 #[cfg(any(
@@ -559,7 +559,7 @@ macro_rules! usart {
             }
 
             /// DMA operations.
-            #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             impl Rx<$USARTX> {
                 pub fn read_all<Buffer, Channel>(self,
                     dma:     &mut dma::Handle,
@@ -678,7 +678,7 @@ macro_rules! usart {
                 }
             }
 
-            #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             impl Tx<$USARTX> {
                 pub fn write_all<Buffer, Channel>(self,
                     dma:     &mut dma::Handle,


### PR DESCRIPTION
Tested the change on my STM32L051T6 board with serial_dma_async example.

I also had to fix the serial_dma_async itself as the heapless `Queue::new()` creates a queue with capacity `N-1`: https://docs.rs/heapless/0.7.1/heapless/spsc/struct.Queue.html#method.new