### PR TITLE
Upgrade `stm32l0` to v0.15.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,6 @@ jobs:
           target: thumbv6m-none-eabi
       - uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: clippy
           # dummy feature to satisfy build.rs
           args: --features mcu-STM32L083VZTx -- -D warnings
@@ -50,7 +49,6 @@ jobs:
           target: thumbv6m-none-eabi
       - uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: package
           args: --no-verify
   build_and_test:
@@ -80,6 +78,5 @@ jobs:
         env:
           RUSTFLAGS: "-D warnings"
         with:
-          use-cross: true
           command: build
           args: --release --examples --features "${{ matrix.features }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-
-
 ## [Unreleased]
 
 <!-- When making a PR, please update this section. Note: This document should
@@ -18,7 +16,7 @@ forget to update the links at the bottom of the changelog as well.-->
 ### Breaking Changes
 
 - Upgrade `stm32l0` to latest version, and other dependency updates ([#215]):
-  
+
   `dependencies`
 
   | crate       | from   | to     |
@@ -40,10 +38,10 @@ forget to update the links at the bottom of the changelog as well.-->
 ### Non-Breaking Changes
 
 ### Fixes
+
 - Add other possible pins for SPI1 for L0x1 family
 
 ### Documentation
-
 
 ## [v0.9.0] - 2021-12-11
 
@@ -65,61 +63,57 @@ forget to update the links at the bottom of the changelog as well.-->
 
 - Fix Cargo features used by docs.rs ([#203])
 
-
 ## [v0.8.0] - 2021-11-04
 
 ### Additions
 
 - Add `Timer::new` to create timer without starting. ([#152])
-- Add (untested) example `temperature` ([#161]) which uses `adc` to read the
-  internal temperature and also an externally connected TMP36 analog sensor.
-- Add `Pwm::set_frequency` to allow dynamically changing the underlying PWM timer's
-  frequency. This was previously impossible without resorting to `unsafe` because the
-  channels where moved out of the timer struct and Rust's ownership rules forbade us
-  to borrow the timer to call `set_frequency`. ([#174])
-- Add Cargo features for flash and RAM sizes allowing to pass the correct sizes to
-  the linker instead of having a default for the whole sub-family. ([#173])
+- Add (untested) example `temperature` ([#161]) which uses `adc` to read the internal temperature
+  and also an externally connected TMP36 analog sensor.
+- Add `Pwm::set_frequency` to allow dynamically changing the underlying PWM timer's frequency. This
+  was previously impossible without resorting to `unsafe` because the channels where moved out of
+  the timer struct and Rust's ownership rules forbade us to borrow the timer to call
+  `set_frequency`. ([#174])
+- Add Cargo features for flash and RAM sizes allowing to pass the correct sizes to the linker
+  instead of having a default for the whole sub-family. ([#173])
 
 ### Breaking Changes
 
-- Migrate from custom `Hertz` implementation to [`embedded-time`](https://crates.io/crates/embedded-time) ([#183])
+- Migrate from custom `Hertz` implementation to
+  [`embedded-time`](https://crates.io/crates/embedded-time) ([#183])
 - Add `enable` to `GeneralPurposeTimer`
 - `Instance::clock_frequency` is now an associated function and doesn't take `&self` anymore.
 - Build script requires that exactly one `flash-*` and one `ram-*` feature is enabled. They are
-  enabled automatically when using an `mcu-*` feature, but if you manually selected the other features
-  before this will break the build because of the missing features.
-- The `rtc::RTC` struct has been renamed to `rtc::Rtc` and includes a big
-  refactoring and a few API changes. It now implements the traits from the
-  [rtcc crate](https://docs.rs/rtcc/) and uses date/time types from Chrono.
-- When downgrading GPIO pins, not only the pin number but also the port
-  identifier is erased. To update your code, replace
-  `PA`/`PB`/`PC`/`PD`/`PE`/`PH` with `Pin`. ([#190])
+  enabled automatically when using an `mcu-*` feature, but if you manually selected the other
+  features before this will break the build because of the missing features.
+- The `rtc::RTC` struct has been renamed to `rtc::Rtc` and includes a big refactoring and a few API
+  changes. It now implements the traits from the [rtcc crate](https://docs.rs/rtcc/) and uses
+  date/time types from Chrono.
+- When downgrading GPIO pins, not only the pin number but also the port identifier is erased. To
+  update your code, replace `PA`/`PB`/`PC`/`PD`/`PE`/`PH` with `Pin`. ([#190])
 
 ### Non-Breaking Changes
 
-- The crate now has an optional `rtc` feature (enabled by default). The `rtc`
-  module is only available if that feature is enabled. Enabling the feature
-  also pulls in the `rtcc` and `chrono` dependencies, in oder to support a
-  richer calendar / clock API.
+- The crate now has an optional `rtc` feature (enabled by default). The `rtc` module is only
+  available if that feature is enabled. Enabling the feature also pulls in the `rtcc` and `chrono`
+  dependencies, in oder to support a richer calendar / clock API.
 
 ### Fixes
 
 - Fixed potential race condition when flushing the tx serial buffer.
-- Fixed RTC year handling. Previously, the implementation incorrectly assumed
-  that the BCD year 00 corresponds to 1970, but this results in a wrong leap
-  year calculation. The correct time base is the year 2000.
-
+- Fixed RTC year handling. Previously, the implementation incorrectly assumed that the BCD year 00
+  corresponds to 1970, but this results in a wrong leap year calculation. The correct time base is
+  the year 2000.
 
 ## [v0.7.0] - 2021-03-10
 
 ### Additions
 
 - Timers: Add support for TIM6 ([#101])
-- Timers: Implement `LinkedTimer` ([#115]). It is initialized with two hardware
-  timers (either TIM2/TIM3 or TIM21/TIM22). The two timers are configured in
-  master/slave mode so that an overflow of the master timer triggers an update
-  on the slave timer. This way, two 16 bit timers can be combined to a single
-  32 bit timer.  (The STM32L0 does not have 32 bit timers.)
+- Timers: Implement `LinkedTimer` ([#115]). It is initialized with two hardware timers (either
+  TIM2/TIM3 or TIM21/TIM22). The two timers are configured in master/slave mode so that an overflow
+  of the master timer triggers an update on the slave timer. This way, two 16 bit timers can be
+  combined to a single 32 bit timer. (The STM32L0 does not have 32 bit timers.)
 - Remove config tests that prevented stm32l0x1 devices from using ADC with DMA ([#124])
 - Add `enable_lse` method to RCC structure that configures LSE ([#130])
 - Expose factory calibration data ([#121])
@@ -144,8 +138,8 @@ forget to update the links at the bottom of the changelog as well.-->
 ### Fixes
 
 - I2C: Before starting new transaction ensure that both TX and RX buffers are empty ([#98])
-- Detect rollover using positions rather than DMA flags ([#127]). This fixes a
-  faulty DMA buffer overflow in `adc_trig` example ([#104]).
+- Detect rollover using positions rather than DMA flags ([#127]). This fixes a faulty DMA buffer
+  overflow in `adc_trig` example ([#104]).
 - Maximum frequency for stm32l0 increased to 32MHz ([#129])
 - GPIO: Fix `Pin::into_pull_down_input` ([#142])
 
@@ -155,33 +149,24 @@ forget to update the links at the bottom of the changelog as well.-->
 - Port examples to RTFM/RTIC 0.5 ([#100], [#116])
 - Improve README ([#119])
 
-
-
 ## [v0.6.2] - 2020-05-03
 
 _Not yet tracked in this changelog._
-
-
 
 ## [v0.6.1] - 2020-04-08
 
 _Not yet tracked in this changelog._
 
-
-
 ## [v0.6.0] - 2020-04-05
 
 _Not yet tracked in this changelog._
 
-
-
 ## v0.5.0 - 2019-12-02
 
-*Not yet tracked in this changelog.*
-
-
+_Not yet tracked in this changelog._
 
 <!-- Links to pull requests and issues. -->
+
 [#215]: https://github.com/stm32-rs/stm32l0xx-hal/pull/215
 [#208]: https://github.com/stm32-rs/stm32l0xx-hal/pull/208
 [#206]: https://github.com/stm32-rs/stm32l0xx-hal/pull/206
@@ -223,7 +208,8 @@ _Not yet tracked in this changelog._
 [#98]: https://github.com/stm32-rs/stm32l0xx-hal/pull/98
 
 <!-- Links to version diffs. -->
-[Unreleased]: https://github.com/stm32-rs/stm32l0xx-hal/compare/v0.9.0...HEAD
+
+[unreleased]: https://github.com/stm32-rs/stm32l0xx-hal/compare/v0.9.0...HEAD
 [v0.9.0]: https://github.com/stm32-rs/stm32l0xx-hal/compare/v0.8.0...v0.9.0
 [v0.8.0]: https://github.com/stm32-rs/stm32l0xx-hal/compare/v0.7.0...v0.8.0
 [v0.7.0]: https://github.com/stm32-rs/stm32l0xx-hal/compare/v0.6.2...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ forget to update the links at the bottom of the changelog as well.-->
 
 ### Breaking Changes
 
+- Upgrade `stm32l0` to latest version, and other dependency updates ([#215]):
+  
+  `dependencies`
+
+  | crate       | from   | to     |
+  | ----------- | ------ | ------ |
+  | cast        | 0.2.2  | 0.3.0  |
+  | cortex-m-rt | 0.6.8  | 0.7.0  |
+  | rtcc        | 0.2    | 0.3.0  |
+  | stm32l0     | 0.13.0 | 0.15.1 |
+
+  `dev-dependencies`
+
+  | crate                | from  | to    |
+  | -------------------- | ----- | ----- |
+  | aligned              | 0.3.1 | 0.4.1 |
+  | cortex-m-rtic        | 0.5.6 | 1.1.3 |
+  | cortex-m-semihosting | 0.3.2 | 0.5.0 |
+  | panic-semihosting    | 0.5.1 | 0.6.0 |
+
 ### Non-Breaking Changes
 
 ### Fixes
@@ -162,6 +182,7 @@ _Not yet tracked in this changelog._
 
 
 <!-- Links to pull requests and issues. -->
+[#215]: https://github.com/stm32-rs/stm32l0xx-hal/pull/215
 [#208]: https://github.com/stm32-rs/stm32l0xx-hal/pull/208
 [#206]: https://github.com/stm32-rs/stm32l0xx-hal/pull/206
 [#203]: https://github.com/stm32-rs/stm32l0xx-hal/pull/203

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ targets = ["thumbv6m-none-eabi"]
 
 [dependencies]
 as-slice = "0.2.1"
-cast = { version = "0.2.2", default-features = false }
-cortex-m =  "0.7.0"
-cortex-m-rt = "0.6.8"
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
-embedded-time = "0.12.0"
+cast = { version = "0.3.0", default-features = false }
+cortex-m = "0.7.5"
+cortex-m-rt = "0.7.1"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
+embedded-time = "0.12.1"
 nb = "1.0.0"
-rtcc = { version = "0.2", optional = true }
+rtcc = { version = "0.3.0", optional = true }
 stm32l0 = "0.15.1"
 stm32-usbd = { version = "0.6.0", optional = true }
 void = { version = "1.0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ targets = ["thumbv6m-none-eabi"]
 [dependencies]
 as-slice = "0.2.1"
 cast = { version = "0.3.0", default-features = false }
-cortex-m = "0.7.5"
-cortex-m-rt = "0.7.1"
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
-embedded-time = "0.12.1"
+cortex-m = "0.7.0"
+cortex-m-rt = "0.7.0"
+embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-time = "0.12.0"
 nb = "1.0.0"
 rtcc = { version = "0.3.0", optional = true }
 stm32l0 = "0.15.1"
@@ -37,11 +37,11 @@ void = { version = "1.0.2", default-features = false }
 aligned = "0.4.1"
 cortex-m-rtic = "1.1.3"
 cortex-m-semihosting = "0.5.0"
-heapless = "0.7.16"
+heapless = "0.7.1"
 panic-halt = "0.2.0"
 panic-semihosting = "0.6.0"
-usb-device = "0.2.9"
-usbd-serial = "0.1.1"
+usb-device = "0.2.3"
+usbd-serial = "0.1.0"
 
 [features]
 # Default features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ embedded-hal = { version = "0.2.3", features = ["unproven"] }
 embedded-time = "0.12.0"
 nb = "1.0.0"
 rtcc = { version = "0.2", optional = true }
-stm32l0 = "0.13.0"
+stm32l0 = "0.15.1"
 stm32-usbd = { version = "0.6.0", optional = true }
 void = { version = "1.0.2", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,14 @@ stm32-usbd = { version = "0.6.0", optional = true }
 void = { version = "1.0.2", default-features = false }
 
 [dev-dependencies]
-aligned = "0.3.1"
-cortex-m-rtic = "0.5.6"
-cortex-m-semihosting = "0.3.2"
-heapless = "0.7.1"
+aligned = "0.4.1"
+cortex-m-rtic = "1.1.3"
+cortex-m-semihosting = "0.5.0"
+heapless = "0.7.16"
 panic-halt = "0.2.0"
-panic-semihosting = "0.5.1"
-usb-device = "0.2.3"
-usbd-serial = "0.1.0"
+panic-semihosting = "0.6.0"
+usb-device = "0.2.9"
+usbd-serial = "0.1.1"
 
 [features]
 # Default features

--- a/examples/mco.rs
+++ b/examples/mco.rs
@@ -27,13 +27,13 @@ fn main() -> ! {
     let gpioa = dp.GPIOA.split(&mut rcc);
 
     // Source MCO from HSI16, configure prescaler to divide by 8 to get 2MHz output.
-    rcc.configure_mco(MCOSEL_A::HSI16, MCOPRE_A::DIV8, (gpioa.pa8, gpioa.pa9));
+    rcc.configure_mco(MCOSEL_A::Hsi16, MCOPRE_A::Div8, (gpioa.pa8, gpioa.pa9));
 
     // Individual pins can also be set by passing them directly:
-    // rcc.enable_mco(MCOSEL_A::HSI16, MCOPRE_A::DIV8, gpioa.pa8);
+    // rcc.enable_mco(MCOSEL_A::Hsi16, MCOPRE_A::Div8, gpioa.pa8);
 
     // Or for larger devices, all 3 MCO pins can be configured:
-    // rcc.configure_mco(MCOSEL_A::HSI16, MCOPRE_A::DIV8, (gpioa.pa8, gpioa.pa9, gpiob.pb13));
+    // rcc.configure_mco(MCOSEL_A::Hsi16, MCOPRE_A::Div8, (gpioa.pa8, gpioa.pa9, gpiob.pb13));
 
     // Probe PA8 or PA9 to see generated 2MHz MCO signal.
     loop {}

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -110,10 +110,10 @@ fn main() -> ! {
 
     loop {
         let mcu_value = mcutemp.read_tempc(&mut adc);
-        hprintln!("inaccurate MCU temp: {}", mcu_value).unwrap();
+        hprintln!("inaccurate MCU temp: {}", mcu_value);
 
         let tmp36_mv: u32 = tmp36.read_mv(&mut adc);
         let tmp36_temp: i32 = tmp36.read_tempc(&mut adc);
-        hprintln!("external sensor: {} mV,   {} C.", tmp36_mv, tmp36_temp).unwrap();
+        hprintln!("external sensor: {} mV,   {} C.", tmp36_mv, tmp36_temp);
     }
 }

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -63,10 +63,10 @@ impl AES {
     {
         // Write key. This is safe, as the register accepts the full range of
         // `u32`.
-        self.aes.keyr0.write(|w| unsafe { w.bits(key[0]) });
-        self.aes.keyr1.write(|w| unsafe { w.bits(key[1]) });
-        self.aes.keyr2.write(|w| unsafe { w.bits(key[2]) });
-        self.aes.keyr3.write(|w| unsafe { w.bits(key[3]) });
+        self.aes.keyr0.write(|w| w.bits(key[0]));
+        self.aes.keyr1.write(|w| w.bits(key[1]));
+        self.aes.keyr2.write(|w| w.bits(key[2]));
+        self.aes.keyr3.write(|w| w.bits(key[3]));
 
         mode.prepare(&self.aes);
 
@@ -164,7 +164,7 @@ impl Tx {
                 let word = word.try_into().unwrap();
                 let word = u32::from_le_bytes(word);
 
-                unsafe { w.bits(word) }
+                w.bits(word)
             });
         }
 
@@ -420,10 +420,10 @@ pub struct CBC<Mode> {
 impl Mode for CBC<Encrypt> {
     fn prepare(&self, aes: &aes::RegisterBlock) {
         // Safe, as the registers accept the full range of `u32`.
-        aes.ivr3.write(|w| unsafe { w.bits(self.init_vector[0]) });
-        aes.ivr2.write(|w| unsafe { w.bits(self.init_vector[1]) });
-        aes.ivr1.write(|w| unsafe { w.bits(self.init_vector[2]) });
-        aes.ivr0.write(|w| unsafe { w.bits(self.init_vector[3]) });
+        aes.ivr3.write(|w| w.bits(self.init_vector[0]));
+        aes.ivr2.write(|w| w.bits(self.init_vector[1]));
+        aes.ivr1.write(|w| w.bits(self.init_vector[2]));
+        aes.ivr0.write(|w| w.bits(self.init_vector[3]));
     }
 
     fn select(&self, w: &mut cr::W) {
@@ -442,10 +442,10 @@ impl Mode for CBC<Decrypt> {
         derive_key(aes);
 
         // Safe, as the registers accept the full range of `u32`.
-        aes.ivr3.write(|w| unsafe { w.bits(self.init_vector[0]) });
-        aes.ivr2.write(|w| unsafe { w.bits(self.init_vector[1]) });
-        aes.ivr1.write(|w| unsafe { w.bits(self.init_vector[2]) });
-        aes.ivr0.write(|w| unsafe { w.bits(self.init_vector[3]) });
+        aes.ivr3.write(|w| w.bits(self.init_vector[0]));
+        aes.ivr2.write(|w| w.bits(self.init_vector[1]));
+        aes.ivr1.write(|w| w.bits(self.init_vector[2]));
+        aes.ivr0.write(|w| w.bits(self.init_vector[3]));
     }
 
     fn select(&self, w: &mut cr::W) {
@@ -475,10 +475,10 @@ impl Mode for CTR {
         // Initialize initialization vector
         //
         // See STM32L0x2 reference manual, table 78 on page 408.
-        aes.ivr3.write(|w| unsafe { w.bits(self.init_vector[0]) });
-        aes.ivr2.write(|w| unsafe { w.bits(self.init_vector[1]) });
-        aes.ivr1.write(|w| unsafe { w.bits(self.init_vector[2]) });
-        aes.ivr0.write(|w| unsafe { w.bits(0x0001) }); // counter
+        aes.ivr3.write(|w| w.bits(self.init_vector[0]));
+        aes.ivr2.write(|w| w.bits(self.init_vector[1]));
+        aes.ivr1.write(|w| w.bits(self.init_vector[2]));
+        aes.ivr0.write(|w| w.bits(0x0001)); // counter
     }
 
     fn select(&self, w: &mut cr::W) {

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -120,8 +120,8 @@ impl Config {
             Some(BitReversal::ByWord) => 0b11,
         };
 
-        crc.init.write(|w| unsafe { w.bits(init) });
-        crc.pol.write(|w| unsafe { w.bits(poly) });
+        crc.init.write(|w| w.bits(init));
+        crc.pol.write(|w| w.bits(poly));
         crc.cr.write(|w| {
             w.rev_in()
                 .bits(in_rev_bits)
@@ -161,7 +161,7 @@ impl Crc {
     pub fn reset_with_inital_value(&mut self, initial_value: u32) {
         let crc = unsafe { &(*CRC::ptr()) };
 
-        crc.init.write(|w| unsafe { w.bits(initial_value) });
+        crc.init.write(|w| w.bits(initial_value));
         crc.cr.modify(|_, w| w.reset().set_bit());
     }
 
@@ -170,7 +170,7 @@ impl Crc {
     pub fn feed(&mut self, data: &[u8]) {
         let crc = unsafe { &(*CRC::ptr()) };
         for &byte in data {
-            crc.dr8().write(|w| unsafe { w.bits(byte) });
+            crc.dr8().write(|w| w.bits(byte));
         }
     }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -242,19 +242,19 @@ pub struct Priority(cr::PL_A);
 
 impl Priority {
     pub fn low() -> Self {
-        Self(cr::PL_A::LOW)
+        Self(cr::PL_A::Low)
     }
 
     pub fn medium() -> Self {
-        Self(cr::PL_A::MEDIUM)
+        Self(cr::PL_A::Medium)
     }
 
     pub fn high() -> Self {
-        Self(cr::PL_A::HIGH)
+        Self(cr::PL_A::High)
     }
 
     pub fn very_high() -> Self {
-        Self(cr::PL_A::VERYHIGH)
+        Self(cr::PL_A::VeryHigh)
     }
 }
 
@@ -263,11 +263,11 @@ pub(crate) struct Direction(cr::DIR_A);
 
 impl Direction {
     pub fn memory_to_peripheral() -> Self {
-        Self(cr::DIR_A::FROMMEMORY)
+        Self(cr::DIR_A::FromMemory)
     }
 
     pub fn peripheral_to_memory() -> Self {
-        Self(cr::DIR_A::FROMPERIPHERAL)
+        Self(cr::DIR_A::FromPeripheral)
     }
 }
 
@@ -644,19 +644,19 @@ pub trait SupportedWordSize {
 
 impl SupportedWordSize for u8 {
     fn size() -> cr::MSIZE_A {
-        cr::MSIZE_A::BITS8
+        cr::MSIZE_A::Bits8
     }
 }
 
 impl SupportedWordSize for u16 {
     fn size() -> cr::MSIZE_A {
-        cr::MSIZE_A::BITS16
+        cr::MSIZE_A::Bits16
     }
 }
 
 impl SupportedWordSize for u32 {
     fn size() -> cr::MSIZE_A {
-        cr::MSIZE_A::BITS32
+        cr::MSIZE_A::Bits32
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -131,9 +131,9 @@ macro_rules! encoders {
                             // Count edges on TI1, direction set by TI2
                             .sms()
                             .variant(match mode {
-                                Mode::CountTi1 => <$sms>::ENCODER_MODE_1,
-                                Mode::CountTi2 => <$sms>::ENCODER_MODE_2,
-                                Mode::Qei => <$sms>::ENCODER_MODE_3,
+                                Mode::CountTi1 => <$sms>::EncoderMode1,
+                                Mode::CountTi2 => <$sms>::EncoderMode2,
+                                Mode::Qei => <$sms>::EncoderMode3,
                             })
                     });
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -260,8 +260,8 @@ where
         self.start_transfer(
             address,
             buffer.as_slice().len(),
-            RD_WRN_A::WRITE,
-            AUTOEND_A::AUTOMATIC,
+            RD_WRN_A::Write,
+            AUTOEND_A::Automatic,
         );
 
         // This token represents the transmission capability of I2C and this is
@@ -339,8 +339,8 @@ where
         self.start_transfer(
             address,
             buffer.as_slice().len(),
-            RD_WRN_A::READ,
-            AUTOEND_A::AUTOMATIC,
+            RD_WRN_A::Read,
+            AUTOEND_A::Automatic,
         );
 
         // See explanation of tokens in `write_all`.
@@ -395,9 +395,9 @@ where
             self.i2c.isr.write(|w| w.txe().set_bit());
 
             if reading {
-                self.start_transfer(addr, bytes.len(), RD_WRN_A::WRITE, AUTOEND_A::SOFTWARE);
+                self.start_transfer(addr, bytes.len(), RD_WRN_A::Write, AUTOEND_A::Software);
             } else {
-                self.start_transfer(addr, bytes.len(), RD_WRN_A::WRITE, AUTOEND_A::AUTOMATIC);
+                self.start_transfer(addr, bytes.len(), RD_WRN_A::Write, AUTOEND_A::Automatic);
             }
 
             // Send bytes
@@ -421,7 +421,7 @@ where
             self.i2c.rxdr.read();
 
             //send a new start condition and transfer
-            self.start_transfer(addr, buffer.len(), RD_WRN_A::READ, AUTOEND_A::AUTOMATIC);
+            self.start_transfer(addr, buffer.len(), RD_WRN_A::Read, AUTOEND_A::Automatic);
 
             // Receive bytes into buffer
             for c in buffer {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -272,14 +272,14 @@ macro_rules! linked_timers {
                     // In the MMS (Master Mode Selection) register, set the master mode so
                     // that a rising edge is output on the trigger output TRGO every time
                     // an update event is generated.
-                    tim_primary.cr2.modify(|_, w| w.mms().variant(<$mms>::UPDATE));
+                    tim_primary.cr2.modify(|_, w| w.mms().variant(<$mms>::Update));
 
                     // In the SMCR (Slave Mode Control Register), select the
                     // appropriate internal trigger source (TS).
                     tim_secondary.smcr.modify(|_, w| w.ts().variant($ts));
                     // Set the SMS (Slave Mode Selection) register to "external clock mode 1",
                     // where the rising edges of the selected trigger (TRGI) clock the counter.
-                    tim_secondary.smcr.modify(|_, w| w.sms().variant(<$sms>::EXT_CLOCK_MODE));
+                    tim_secondary.smcr.modify(|_, w| w.sms().variant(<$sms>::ExtClockMode));
 
                     Self { tim_primary, tim_secondary }
                 }
@@ -344,9 +344,9 @@ timers! {
 
 linked_timers! {
     // Internal trigger connection: RM0377 table 76
-    (TIM2, TIM3): (tim2_tim3, tim2::cr2::MMS_A, tim2::smcr::SMS_A, tim2::smcr::TS_A::ITR0),
+    (TIM2, TIM3): (tim2_tim3, tim2::cr2::MMS_A, tim2::smcr::SMS_A, tim2::smcr::TS_A::Itr0),
     // Internal trigger connection: RM0377 table 80
-    (TIM21, TIM22): (tim21_tim22, tim21::cr2::MMS_A, tim22::smcr::SMS_A, tim22::smcr::TS_A::ITR0),
+    (TIM21, TIM22): (tim21_tim22, tim21::cr2::MMS_A, tim22::smcr::SMS_A, tim22::smcr::TS_A::Itr0),
 
     // Note: Other combinations would be possible as well, e.g. (TIM21, TIM2) or (TIM2, TIM22).
     // They can be implemented if needed.

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -13,7 +13,7 @@
 //! fits together.
 
 use crate::{
-    pac::{self, RCC},
+    pac,
     rcc::{Enable, Reset, HSI48},
 };
 use stm32_usbd::UsbPeripheral;


### PR DESCRIPTION
Mostly mechanical changes resulting from the `stm32l0` crate upgrade.

I also:

1. Removed `cross` from CI as it was breaking things and I don't see the value in using it
2. Upgraded to a newer RTIC for the examples that use it

Closes #198.