### PR TITLE
Make Exti::TriggerEdge enum behave as constant (Copy+Clone+Eq+..)

### DIFF
--- a/src/exti.rs
+++ b/src/exti.rs
@@ -9,6 +9,7 @@ use crate::{gpio, pac};
 use cortex_m::{interrupt, peripheral::NVIC};
 
 /// Edges that can trigger a configurable interrupt line.
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum TriggerEdge {
     /// Trigger on rising edges only.
     Rising,


### PR DESCRIPTION
Exti::TriggerEdge is a plain enum and it should be possible to pass it by value without move. All the other enums in the exti module behave this way too.