### PR TITLE
Use either LSI or LSE in RTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ forget to update the links at the bottom of the changelog as well.-->
 
 ### Breaking Changes
 
+- Allow selection of RTC clock source to be LSE or LSI ([#218])
+
 ### Non-Breaking Changes
 
 ### Fixes
@@ -179,6 +181,7 @@ _Not yet tracked in this changelog._
 
 <!-- Links to pull requests and issues. -->
 
+[#218]: https://github.com/stm32-rs/stm32l0xx-hal/pull/218
 [#215]: https://github.com/stm32-rs/stm32l0xx-hal/pull/215
 [#208]: https://github.com/stm32-rs/stm32l0xx-hal/pull/208
 [#206]: https://github.com/stm32-rs/stm32l0xx-hal/pull/206

--- a/examples/pwr.rs
+++ b/examples/pwr.rs
@@ -12,7 +12,7 @@ use stm32l0xx_hal::{
     prelude::*,
     pwr::{self, PWR},
     rcc,
-    rtc::{self, Rtc},
+    rtc::{self, ClockSource, Rtc},
 };
 
 #[entry]
@@ -29,7 +29,7 @@ fn main() -> ! {
     let mut led = gpiob.pb2.into_push_pull_output().downgrade();
 
     // Initialize RTC
-    let mut rtc = Rtc::new(dp.RTC, &mut rcc, &mut pwr, None).unwrap();
+    let mut rtc = Rtc::new(dp.RTC, &mut rcc, &pwr, ClockSource::LSI, None).unwrap();
 
     // Enable interrupts
     let exti_line = ConfigurableLine::RtcWakeup;

--- a/examples/rtc.rs
+++ b/examples/rtc.rs
@@ -21,7 +21,7 @@ use stm32l0xx_hal::{
     prelude::*,
     pwr::PWR,
     rcc,
-    rtc::{Instant, RTC},
+    rtc::{ClockSource, Instant, Rtc},
     serial,
 };
 
@@ -55,7 +55,9 @@ fn main() -> ! {
         .set_minute(36)
         .set_second(0);
 
-    let mut rtc = RTC::new(dp.RTC, &mut rcc, &mut pwr, instant);
+    // If the target hardware has an external crystal, ClockSource::LSE can be used
+    // instead of ClockSource::LSI for greater accuracy
+    let mut rtc = Rtc::new(dp.RTC, &mut rcc, &pwr, ClockSource::LSI, instant);
 
     loop {
         let mut instant = rtc.now();

--- a/examples/rtc_wakeup.rs
+++ b/examples/rtc_wakeup.rs
@@ -10,7 +10,7 @@ use stm32l0xx_hal::{
     prelude::*,
     pwr::PWR,
     rcc,
-    rtc::{self, Rtc},
+    rtc::{self, ClockSource, Rtc},
 };
 
 #[entry]
@@ -32,7 +32,9 @@ fn main() -> ! {
     let mut exti = Exti::new(dp.EXTI);
     let mut pwr = PWR::new(dp.PWR, &mut rcc);
 
-    let mut rtc = Rtc::new(dp.RTC, &mut rcc, &mut pwr, None).unwrap();
+    // If the target hardware has an external crystal, ClockSource::LSE can be used
+    // instead of ClockSource::LSI for greater accuracy
+    let mut rtc = Rtc::new(dp.RTC, &mut rcc, &pwr, ClockSource::LSI, None).unwrap();
 
     let exti_line = ConfigurableLine::RtcWakeup;
 

--- a/src/aes.rs
+++ b/src/aes.rs
@@ -261,7 +261,7 @@ impl Rx {
             let word = doutr.read().bits();
             let word = word.to_le_bytes();
 
-            (&mut block[i..i + 4]).copy_from_slice(&word);
+            (block[i..i + 4]).copy_from_slice(&word);
         }
 
         // Clear CCF flag

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -214,6 +214,7 @@ impl core::ops::Deref for Rcc {
 }
 
 impl Rcc {
+    /// Enable the Low Speed External (LSE) clock.
     pub fn enable_lse(&mut self, _: &PWR) -> LSE {
         self.rb.csr.modify(|_, w| {
             // Enable LSE clock
@@ -221,6 +222,16 @@ impl Rcc {
         });
         while self.rb.csr.read().lserdy().bit_is_clear() {}
         LSE(())
+    }
+
+    /// Enable the Low Speed Internal (LSI) clock.
+    pub fn enable_lsi(&mut self, _: &PWR) -> LSI {
+        self.rb.csr.modify(|_, w| {
+            // Enable LSI clock
+            w.lsion().set_bit()
+        });
+        while self.rb.csr.read().lsirdy().bit_is_clear() {}
+        LSI(())
     }
 }
 
@@ -503,11 +514,16 @@ pub struct HSI48(());
 #[derive(Clone, Copy)]
 pub struct MCOEnabled(());
 
-/// Token that exists only, if the LSE clock has been enabled
+/// A token that exists only if the LSE clock has been enabled
 ///
-/// You can get an instance of this struct by calling [`Rcc::enable_lse`].
+/// The token is returned by calling [`Rcc::enable_lse`].
 #[derive(Clone, Copy)]
 pub struct LSE(());
+
+/// A token that exists only if the LSI clock has been enabled
+///
+/// The token is returned by calling [`Rcc::enable_lsi`].
+pub struct LSI(());
 
 /// Bus associated to peripheral
 pub trait RccBus: crate::Sealed {


### PR DESCRIPTION
RTC can be used with an internal or external Low Speed clock (LSE or LSI).  LSE is more accurate but requires an external crystal on the board.   This diff adds the possibility to select LSI or LSE when RTC is
created.

Also, modified existing examples to use LSI.  This prevents them from freezing on boards without an LSE crystal.  None of the examples seem to rely on high timing accuracy.