### PR TITLE
Enable SPI2 on subset of stm32l0x1 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ make upgrading the HAL as painless as possible! If it makes sense, feel free
 to add upgrade notes and examples. When adding an issue or PR reference, don't
 forget to update the links at the bottom of the changelog as well.-->
 
+- Enable SPI2 on subset of stm32l0x1 devices ([#221])
+
 ### Additions
 
 - Add `pause` and `resume` methods to timers ([#220])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -392,6 +392,10 @@ name = "serial_lse"
 required-features = ["stm32l0x2", "io-STM32L071"]
 
 [[example]]
+name = "spi2"
+required-features = ["stm32l0x1", "io-STM32L051"]
+
+[[example]]
 name = "timer"
 required-features = ["rt"]
 

--- a/examples/rtc_low_apb1.rs
+++ b/examples/rtc_low_apb1.rs
@@ -29,7 +29,10 @@ fn main() -> ! {
     let mut led = gpiob.pb5.into_push_pull_output();
 
     // Initialize RTC
-    let init = NaiveDate::from_ymd(2019, 8, 9).and_hms(13, 37, 42);
+    let init = NaiveDate::from_ymd_opt(2019, 8, 9)
+        .unwrap()
+        .and_hms_opt(13, 37, 42)
+        .unwrap();
     // If the target hardware has an external crystal, ClockSource::LSE can be used
     // instead of ClockSource::LSI for greater accuracy
     let mut rtc = Rtc::new(dp.RTC, &mut rcc, &pwr, ClockSource::LSI, Some(init)).unwrap();

--- a/examples/spi2.rs
+++ b/examples/spi2.rs
@@ -1,0 +1,55 @@
+//! An example to show the configuration and usage of SPI1 and SPI2 on `stm32l0x2`, `stm32l0x3` and
+//! the subset of `stm32l0x1` series that have two SPI ports
+//!
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use stm32l0xx_hal::{pac, prelude::*, rcc::Config, spi};
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Configure the clock.
+    let mut rcc = dp.RCC.freeze(Config::hsi16());
+
+    // Acquire the GPIOA peripheral. This also enables the clock for GPIOA in
+    // the RCC register.
+    let gpioa = dp.GPIOA.split(&mut rcc);
+
+    let mut nss = gpioa.pa4.into_push_pull_output();
+    let sck = gpioa.pa5;
+    let miso = gpioa.pa6;
+    let mosi = gpioa.pa7;
+
+    // Initialise the SPI1 peripheral.
+    let mut spi = dp
+        .SPI1
+        .spi((sck, miso, mosi), spi::MODE_0, 100_000.Hz(), &mut rcc);
+
+    let gpiob = dp.GPIOB.split(&mut rcc);
+
+    let mut nss2 = gpiob.pb12.into_push_pull_output();
+    let sck2 = gpiob.pb13;
+    let miso2 = gpiob.pb14;
+    let mosi2 = gpiob.pb15;
+
+    // Initialise the SPI2 peripheral.
+    let mut spi2 = dp
+        .SPI2
+        .spi((sck2, miso2, mosi2), spi::MODE_0, 100_000.Hz(), &mut rcc);
+
+    loop {
+        nss.set_low().unwrap();
+        spi.write(&[0, 1]).unwrap();
+        nss.set_high().unwrap();
+
+        nss2.set_low().unwrap();
+        spi2.write(&[0, 1]).unwrap();
+        nss2.set_high().unwrap();
+    }
+}

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -171,7 +171,12 @@ impl Rtc {
 
         // Initialize RTC, if not yet initialized
         if rtc.rtc.isr.read().inits().bit_is_clear() {
-            rtc.set(init.unwrap_or_else(|| NaiveDate::from_ymd(2001, 1, 1).and_hms(0, 0, 0)))?;
+            rtc.set(init.unwrap_or_else(|| {
+                NaiveDate::from_ymd_opt(2001, 1, 1)
+                    .unwrap()
+                    .and_hms_opt(0, 0, 0)
+                    .unwrap()
+            }))?;
         }
 
         // Disable wakeup timer. It's periodic and persists over resets, but for
@@ -315,7 +320,10 @@ impl Rtc {
         let minute = bcd2_decode(tr.mnt().bits(), tr.mnu().bits());
         let second = bcd2_decode(tr.st().bits(), tr.su().bits());
 
-        NaiveDate::from_ymd(year, month, day).and_hms(hour, minute, second)
+        NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(hour, minute, second)
+            .unwrap()
     }
 
     /// Enable interrupts

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -16,7 +16,12 @@ use crate::gpio::gpiob::*;
 use crate::gpio::{AltMode, Analog};
 use crate::hal;
 use crate::pac::SPI1;
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(
+    feature = "io-STM32L051",
+    feature = "io-STM32L071",
+    feature = "stm32l0x2",
+    feature = "stm32l0x3"
+))]
 use crate::pac::SPI2;
 use crate::rcc::{Enable, Rcc};
 
@@ -131,7 +136,12 @@ pins! {
         ]
 }
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(
+    feature = "io-STM32L051",
+    feature = "io-STM32L071",
+    feature = "stm32l0x2",
+    feature = "stm32l0x3"
+))]
 pins! {
     SPI2:
         SCK: [
@@ -435,7 +445,12 @@ spi! {
     SPI1: (spi1, apb2_clk),
 }
 
-#[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
+#[cfg(any(
+    feature = "io-STM32L051",
+    feature = "io-STM32L071",
+    feature = "stm32l0x2",
+    feature = "stm32l0x3"
+))]
 spi! {
     SPI2: (spi2, apb1_clk),
 }


### PR DESCRIPTION
There are members of the stm32l0x1 subfamily that thave two SPIs.  In
particular the STM32l051 and the STM32l071.
    
Compile tested as:
    
    cargo build --release --example spi2 --features mcu-STM32L051C8Tx
(builds)
    
    cargo build --release --example spi2  --features mcu-STM32L031C6Tx
(fails to build, as this subfamily only has 1 SPI)
    
but not run on actual hardware.