### PR TITLE
Disable regulator when entering Stop on STM32l0x1

### DIFF
--- a/examples/pwr.rs
+++ b/examples/pwr.rs
@@ -70,6 +70,7 @@ fn main() -> ! {
 
     // 5 seconds of low-power sleep mode
     exti.wait_for_irq(exti_line, pwr.low_power_sleep_mode(&mut scb, &mut rcc));
+    pwr.exit_low_power_run_mode();
     timer.wait().unwrap(); // returns immediately; we just got the interrupt
 
     blink(&mut led);

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -336,7 +336,13 @@ impl PowerMode for StopMode<'_> {
             // Enter Stop mode
             w.pdds().stop_mode();
             // Disable internal voltage regulator
-            w.lpds().set_bit()
+            // Cat 1 devices of stm32l0x1 family do this differently than the rest
+            if cfg!(feature = "io-STM32L021") {
+                w.lpsdsr().clear_bit();
+                w.lpds().set_bit()
+            } else {
+                w.lpsdsr().set_bit()
+            }
         });
 
         // Wait for WUF to be cleared


### PR DESCRIPTION
Only category 1 devices of the STM32l0x1 family have a `lpds` bit on the power configuration register.  Categories 2 and above use the `lpsdsr` bit instead.  On STM32l0x2 and STM32l0x3, these two bits are aliased in the stm32l0 crate, so `cr.lpds()` and `cr.lpsdsr()` will modify the same bit.

Tested by compiling the `pwr.rs` example and running it on a STM32L051C8Tx. With the fix, the stop current is reduced by 13.4 uA.

cargo build --release --example pwr --features mcu-STM32L051C8Tx

The problem could not be measured in the `pwr.rs` example because in it the device is put into low-power sleep mode before entering stop. That code accidentally left the `lpsdsr` bit set which would then affect the stop mode that followed.  Fix this by properly exiting low power sleep.