### PR TITLE
Enable all output pins for TIM2 on all devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ make upgrading the HAL as painless as possible! If it makes sense, feel free
 to add upgrade notes and examples. When adding an issue or PR reference, don't
 forget to update the links at the bottom of the changelog as well.-->
 
-- Enable SPI2 on subset of stm32l0x1 devices ([#221])
-
 ### Additions
 
+- Enable TIM2 outputs on `PA5`, `PA15`, `PB3` for all devices in the L0 family (previously only 0x2
+  and 0x3) ([#224])
+- Enable SPI2 on subset of stm32l0x1 devices ([#221])
 - Add `pause` and `resume` methods to timers ([#220])
 
 ### Breaking Changes
@@ -185,6 +186,8 @@ _Not yet tracked in this changelog._
 
 <!-- Links to pull requests and issues. -->
 
+[#224]: https://github.com/stm32-rs/stm32l0xx-hal/pull/224
+[#221]: https://github.com/stm32-rs/stm32l0xx-hal/pull/221
 [#220]: https://github.com/stm32-rs/stm32l0xx-hal/pull/218
 [#218]: https://github.com/stm32-rs/stm32l0xx-hal/pull/218
 [#215]: https://github.com/stm32-rs/stm32l0xx-hal/pull/215

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1,4 +1,8 @@
 use crate::gpio::gpioa::{PA0, PA1, PA2, PA3};
+use crate::gpio::{
+    gpioa::{PA15, PA5},
+    gpiob::PB3,
+};
 use crate::gpio::{AltMode, PinMode};
 use crate::hal;
 use crate::pac::{tim2, TIM2, TIM3};
@@ -10,10 +14,7 @@ use cortex_m::interrupt;
 use embedded_time::rate::Hertz;
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
-use crate::gpio::{
-    gpioa::{PA15, PA5},
-    gpiob::{PB10, PB11, PB3},
-};
+use crate::gpio::gpiob::{PB10, PB11};
 
 #[cfg(any(feature = "stm32l072", feature = "stm32l082", feature = "io-STM32L071",))]
 use crate::gpio::{
@@ -299,15 +300,15 @@ impl_pin!(
         PA1, C2, AF2;
         PA2, C3, AF2;
         PA3, C4, AF2;
+        PA5,  C1, AF5;
+        PA15, C1, AF5;
+        PB3,  C2, AF2;
     )
 );
 
 #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
 impl_pin!(
     TIM2: (
-        PA5,  C1, AF5;
-        PA15, C1, AF5;
-        PB3,  C2, AF2;
         PB10, C3, AF2;
         PB11, C4, AF2;
     )


### PR DESCRIPTION
Looking through some ST datasheets/RMs, TIM2 can output on the pins changed in this PR from the x011 range all the way up to the largest chips in the L0 family.

Closes #219 