### PR TITLE
Allow pin modes OpenDrain and PushPull for SPI output pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ forget to update the links at the bottom of the changelog as well.-->
 
 ### Additions
 
+- SPI: Allow output pins of mode `PushPull` and `OpenDrain` ([#226])
 - Enable TIM2 outputs on `PA5`, `PA15`, `PB3` for all devices in the L0 family (previously only 0x2
   and 0x3) ([#224])
 - Enable SPI2 on subset of stm32l0x1 devices ([#221])
@@ -186,6 +187,7 @@ _Not yet tracked in this changelog._
 
 <!-- Links to pull requests and issues. -->
 
+[#226]: https://github.com/stm32-rs/stm32l0xx-hal/pull/226
 [#224]: https://github.com/stm32-rs/stm32l0xx-hal/pull/224
 [#221]: https://github.com/stm32-rs/stm32l0xx-hal/pull/221
 [#220]: https://github.com/stm32-rs/stm32l0xx-hal/pull/218

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -22,7 +22,7 @@ pub enum ClockSrc {
 ///
 /// These ranges control the frequency of the MSI. Internally, these ranges map
 /// to the `MSIRANGE` bits in the `RCC_ICSCR` register.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub enum MSIRange {
     /// Around 65.536 kHz
     Range0 = 0,
@@ -35,15 +35,10 @@ pub enum MSIRange {
     /// Around 1.048 MHz
     Range4 = 4,
     /// Around 2.097 MHz (reset value)
+    #[default]
     Range5 = 5,
     /// Around 4.194 MHz
     Range6 = 6,
-}
-
-impl Default for MSIRange {
-    fn default() -> MSIRange {
-        MSIRange::Range5
-    }
 }
 
 /// HSI16 divider

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -13,7 +13,7 @@ use crate::dma::{self, Buffer};
 use crate::gpio::gpioa::*;
 use crate::gpio::gpiob::*;
 
-use crate::gpio::{AltMode, Analog};
+use crate::gpio::{AltMode, Analog, OpenDrain, Output};
 use crate::hal;
 use crate::pac::SPI1;
 #[cfg(any(
@@ -164,6 +164,7 @@ pins! {
         SCK: [
             [NoSck, None],
             [PA5<Analog>, AltMode::AF0],
+            [PA5<Output<OpenDrain>>, AltMode::AF0],
             [PB3<Analog>, AltMode::AF0]
         ]
         MISO: [
@@ -175,6 +176,7 @@ pins! {
         MOSI: [
             [NoMosi, None],
             [PA7<Analog>, AltMode::AF0],
+            [PA7<Output<OpenDrain>>, AltMode::AF0],
             [PA12<Analog>, AltMode::AF0],
             [PB5<Analog>, AltMode::AF0]
         ]

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -13,7 +13,7 @@ use crate::dma::{self, Buffer};
 use crate::gpio::gpioa::*;
 use crate::gpio::gpiob::*;
 
-use crate::gpio::{AltMode, Analog, OpenDrain, Output};
+use crate::gpio::{AltMode, Analog, OpenDrain, Output, PushPull};
 use crate::hal;
 use crate::pac::SPI1;
 #[cfg(any(
@@ -119,8 +119,12 @@ pins! {
     SPI1:
         SCK: [
             [NoSck, None],
+            [PA5<Analog>, AltMode::AF0],
+            [PA5<Output<OpenDrain>>, AltMode::AF0],
+            [PA5<Output<PushPull>>, AltMode::AF0],
             [PB3<Analog>, AltMode::AF0],
-            [PA5<Analog>, AltMode::AF0]
+            [PB3<Output<OpenDrain>>, AltMode::AF0],
+            [PB3<Output<PushPull>>, AltMode::AF0]
         ]
         MISO: [
             [NoMiso, None],
@@ -131,8 +135,14 @@ pins! {
         MOSI: [
             [NoMosi, None],
             [PA7<Analog>, AltMode::AF0],
+            [PA7<Output<OpenDrain>>, AltMode::AF0],
+            [PA7<Output<PushPull>>, AltMode::AF0],
             [PA12<Analog>, AltMode::AF0],
-            [PB5<Analog>, AltMode::AF0]
+            [PA12<Output<OpenDrain>>, AltMode::AF0],
+            [PA12<Output<PushPull>>, AltMode::AF0],
+            [PB5<Analog>, AltMode::AF0],
+            [PB5<Output<OpenDrain>>, AltMode::AF0],
+            [PB5<Output<PushPull>>, AltMode::AF0]
         ]
 }
 
@@ -146,7 +156,9 @@ pins! {
     SPI2:
         SCK: [
             [NoSck, None],
-            [PB13<Analog>, AltMode::AF0]
+            [PB13<Analog>, AltMode::AF0],
+            [PB13<Output<OpenDrain>>, AltMode::AF0],
+            [PB13<Output<PushPull>>, AltMode::AF0]
         ]
         MISO: [
             [NoMiso, None],
@@ -154,7 +166,9 @@ pins! {
         ]
         MOSI: [
             [NoMosi, None],
-            [PB15<Analog>, AltMode::AF0]
+            [PB15<Analog>, AltMode::AF0],
+            [PB15<Output<OpenDrain>>, AltMode::AF0],
+            [PB15<Output<PushPull>>, AltMode::AF0]
         ]
 }
 
@@ -165,7 +179,10 @@ pins! {
             [NoSck, None],
             [PA5<Analog>, AltMode::AF0],
             [PA5<Output<OpenDrain>>, AltMode::AF0],
-            [PB3<Analog>, AltMode::AF0]
+            [PA5<Output<PushPull>>, AltMode::AF0],
+            [PB3<Analog>, AltMode::AF0],
+            [PB3<Output<OpenDrain>>, AltMode::AF0],
+            [PB3<Output<PushPull>>, AltMode::AF0]
         ]
         MISO: [
             [NoMiso, None],
@@ -177,8 +194,13 @@ pins! {
             [NoMosi, None],
             [PA7<Analog>, AltMode::AF0],
             [PA7<Output<OpenDrain>>, AltMode::AF0],
+            [PA7<Output<PushPull>>, AltMode::AF0],
             [PA12<Analog>, AltMode::AF0],
-            [PB5<Analog>, AltMode::AF0]
+            [PA12<Output<OpenDrain>>, AltMode::AF0],
+            [PA12<Output<PushPull>>, AltMode::AF0],
+            [PB5<Analog>, AltMode::AF0],
+            [PB5<Output<OpenDrain>>, AltMode::AF0],
+            [PB5<Output<PushPull>>, AltMode::AF0]
         ]
 }
 


### PR DESCRIPTION
I needed to use `OpenDrain` mode for SPI output pins, but the init for SPI were only defined for pins set to `Analog` (i.e. implicitly `PushPull`). Therefore I added `Output<OpenDrain>` as an alternative and also `Output<PushPull>` to allow for more explicit user peripheral setup code. 