### PR TITLE
Skip /32 AHB prescaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ _Not yet tracked in this changelog._
 <!-- Links to pull requests and issues. -->
 
 [#226]: https://github.com/stm32-rs/stm32l0xx-hal/pull/226
+[#228]: https://github.com/stm32-rs/stm32l0xx-hal/pull/228
 [#224]: https://github.com/stm32-rs/stm32l0xx-hal/pull/224
 [#221]: https://github.com/stm32-rs/stm32l0xx-hal/pull/221
 [#220]: https://github.com/stm32-rs/stm32l0xx-hal/pull/218

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ forget to update the links at the bottom of the changelog as well.-->
 
 ### Fixes
 
+- Correct calculation of AHB prescaler for factors > 16 ([#228])
+
 ### Documentation
 
 ## [v0.10.0] - 2022-08-15

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -413,6 +413,8 @@ impl RccExt for RCC {
 
         let ahb_freq = match cfgr.ahb_pre {
             AHBPrescaler::NotDivided => sys_clk,
+            // skip /32
+            pre if pre as u8 & 0b0100 > 0 => sys_clk / (1 << (pre as u8 - 6)),
             pre => sys_clk / (1 << (pre as u8 - 7)),
         };
 


### PR DESCRIPTION
Fixes #225 

There is no /32 AHB prescaler, but the old calculation code assumed there was, causing all calculated clock frequencies with an AHB prescaler > 16 to be off by a factor of 2.

Note that this only affects the frequencies stored in the `Clocks` struct, not the ones actually applied to the AHB frequency.
Page 194 of the [reference manual](https://www.st.com/resource/en/reference_manual/rm0367-ultralowpower-stm32l0x3-advanced-armbased-32bit-mcus-stmicroelectronics.pdf) shows mapping of register bits to prescaler factors. As far as I can see, those are implemented correctly.