### PR TITLE
Fix error "assigning to &T is undefined behavior" and clippy warnings

### DIFF
--- a/src/exti.rs
+++ b/src/exti.rs
@@ -69,7 +69,7 @@ impl Exti {
 
         unsafe {
             match line {
-                0 | 1 | 2 | 3 => {
+                0..=3 => {
                     syscfg.syscfg.exticr1.modify(|_, w| match line {
                         0 => w.exti0().bits(port_bm),
                         1 => w.exti1().bits(port_bm),
@@ -78,7 +78,7 @@ impl Exti {
                         _ => w,
                     });
                 }
-                4 | 5 | 6 | 7 => {
+                4..=7 => {
                     // no need to assert that PH is not port,
                     // since line is assert on port above
                     syscfg.syscfg.exticr2.modify(|_, w| match line {
@@ -89,7 +89,7 @@ impl Exti {
                         _ => w,
                     });
                 }
-                8 | 9 | 10 | 11 => {
+                8..=11 => {
                     syscfg.syscfg.exticr3.modify(|_, w| match line {
                         8 => w.exti8().bits(port_bm),
                         9 => w.exti9().bits(port_bm),
@@ -98,7 +98,7 @@ impl Exti {
                         _ => w,
                     });
                 }
-                12 | 13 | 14 | 15 => {
+                12..=15 => {
                     syscfg.syscfg.exticr4.modify(|_, w| match line {
                         12 => w.exti12().bits(port_bm),
                         13 => w.exti13().bits(port_bm),

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -487,9 +487,9 @@ macro_rules! gpio {
                     pub fn set_speed(self, speed: Speed) -> Self {
                         let offset = 2 * $i;
                         unsafe {
-                            &(*$GPIOX::ptr()).ospeedr.modify(|r, w| {
+                            let _ = &(*$GPIOX::ptr()).ospeedr.modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | ((speed as u32) << offset))
-                            })
+                            });
                         };
                         self
                     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,5 +41,5 @@ pub use crate::serial::{Serial1Ext as _, Serial1LpExt as _};
     feature = "io-STM32L071",
 ))]
 pub use crate::serial::{Serial1LpExt as _, Serial2Ext as _};
-#[cfg(any(feature = "io-STM32L071",))]
+#[cfg(feature = "io-STM32L071")]
 pub use crate::serial::{Serial4Ext as _, Serial5Ext as _};

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,3 +1,4 @@
+use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ptr;
@@ -33,7 +34,7 @@ use crate::dma::Buffer;
 ))]
 use crate::gpio::gpioc::*;
 use crate::gpio::{gpioa::*, gpiob::*};
-#[cfg(any(feature = "io-STM32L071"))]
+#[cfg(feature = "io-STM32L071")]
 use crate::gpio::{gpiod::*, gpioe::*};
 
 /// Serial error
@@ -661,7 +662,7 @@ macro_rules! usart {
                     if isr.txe().bit_is_set() {
                         // NOTE(unsafe) atomic write to stateless register
                         // NOTE(write_volatile) 8-bit write that's not possible through the svd2rust API
-                        unsafe { ptr::write_volatile(&(*$USARTX::ptr()).tdr as *const _ as *mut _, byte) }
+                        unsafe { ptr::write_volatile(UnsafeCell::raw_get(&(*$USARTX::ptr()).tdr as *const _ as _), byte) }
 
                         Ok(())
                     } else {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,4 +1,5 @@
 use core::{
+    cell::UnsafeCell,
     marker::PhantomData,
     ops::{Deref, DerefMut},
     pin::Pin,
@@ -449,7 +450,7 @@ macro_rules! spi {
                         nb::Error::Other(Error::Crc)
                     } else if sr.txe().bit_is_set() {
                         // NOTE(write_volatile) see note above
-                        unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte) }
+                        unsafe { ptr::write_volatile(UnsafeCell::raw_get(&self.spi.dr as *const _ as _), byte) }
                         return Ok(());
                     } else {
                         nb::Error::WouldBlock


### PR DESCRIPTION
Since Rust 1.73.0 there seems to be [a new deny-by-default lint](
https://doc.rust-lang.org/beta/rustc/lints/listing/deny-by-default.html#invalid-reference-casting) to catch invalid casting from references to mutable pointers.

As far as I understand the compiler is making assumptions that references are read only and passing those assumptions on to LLVM. The only way to tell the compiler to not make those assumptions is to use `UnsafeCell`.

So this PR is essentially wrapping those casts with `UnsafeCell` and getting the mutable pointer through it.

In addition to that I fixed some warnings from compiler lints and clippy lints.
