### PR TITLE
Fix shared reference of mutable static warning

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -42,7 +42,7 @@ pub fn device_id_hex() -> &'static str {
             });
         }
 
-        core::str::from_utf8_unchecked(&DEVICE_ID_STR)
+        core::str::from_utf8_unchecked(&*core::ptr::addr_of!(DEVICE_ID_STR))
     }
 }
 


### PR DESCRIPTION
This fixes this warning:

warning: shared reference of mutable static is discouraged
  --> stm32l0xx-hal/src/signature.rs:45:40
   |
45 |         core::str::from_utf8_unchecked(&DEVICE_ID_STR)
   |                                        ^^^^^^^^^^^^^^ shared reference of mutable static
   |
   = note: for more information, see issue #114447 <https://github.com/rust-lang/rust/issues/114447>
   = note: reference of mutable static is a hard error from 2024 edition
   = note: mutable statics can be written to by multiple threads: aliasing violations or data races will cause undefined behavior
   = note: `#[warn(static_mut_ref)]` on by default
help: shared references are dangerous since if there's any kind of mutation of that static while the reference lives, that's UB; use `addr_of!` instead to create a raw pointer