### PR TITLE
Remove reference to non-feature

### DIFF
--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -139,7 +139,7 @@ bus! {
     DBG => (APB2, dbgen, dbgsmen, dbgrst), // 22
 }
 
-#[cfg(any(feature = "stm32l0x0", feature = "stm32l0x1"))]
+#[cfg(feature = "stm32l0x1")]
 bus! {
     WWDG => (APB1, wwdgen, wwdgsmen, wwdgrst), // 11
     USART2 => (APB1, usart2en, usart2smen, usart2rst), // 17


### PR DESCRIPTION
stm32l0x0 is a family, but the PR to merge it never went in, resulting in a warning on master.

Removing the warning for now, would be willing to take a pass at updating the draft PR in the future.