### PR TITLE
Add configuration for Zed editor that enables maximum feature set

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,15 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "cargo": {
+          "features": ["mcu-STM32L083CZTx", "rt", "stm32-usbd", "rtc"]
+        },
+        "check": {
+          "allTargets": false,
+          "targets": "thumbv6m-none-eabi"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Zed is excellent
Add a config that enables Rust Analyzer for all the code in the crate, so it "just works", similar to several other stm32 HALs