### PR TITLE
Add embedded_hal 1.0, keep support for latest 0.2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,23 @@ targets = ["thumbv6m-none-eabi"]
 [dependencies]
 as-slice = "0.2.1"
 cast = { version = "0.3.0", default-features = false }
-cortex-m = "0.7.0"
-cortex-m-rt = "0.7.0"
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+cortex-m = "0.7.7"
+cortex-m-rt = "0.7.5"
 embedded-time = "0.12.0"
 nb = "1.0.0"
 rtcc = { version = "0.3.0", optional = true }
 stm32l0 = "0.15.1"
 stm32-usbd = { version = "0.6.0", optional = true }
 void = { version = "1.0.2", default-features = false }
+
+[dependencies.embedded-hal-02]
+package = "embedded-hal"
+version = "0.2.7"
+features = ["unproven"]
+
+[dependencies.embedded-hal]
+version = "1.0"
+
 
 [dev-dependencies]
 aligned = "0.4.1"

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -10,7 +10,7 @@ use as_slice::AsMutSlice;
 
 use crate::{
     gpio::*,
-    hal::adc::{Channel, OneShot},
+    hal_02::adc::{Channel, OneShot},
     pac::ADC,
     rcc::{Enable, Rcc},
 };

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,6 +1,6 @@
 //! Delays
 
-use crate::hal::blocking::delay::{DelayMs, DelayUs};
+use crate::hal_02::blocking::delay::{DelayMs, DelayUs};
 use crate::rcc::Clocks;
 use cast::u32;
 use core::convert::TryInto;

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -49,7 +49,7 @@ pub struct Output<MODE> {
 /// Push pull output (type state)
 pub struct PushPull;
 
-use embedded_hal::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
+use crate::hal_02::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
 
 /// Fully erased pin
 pub struct Pin<MODE> {
@@ -245,7 +245,7 @@ macro_rules! gpio {
         pub mod $gpiox {
             use core::marker::PhantomData;
 
-            use crate::hal::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
+            use crate::hal_02::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
             use crate::pac::$GPIOX;
             use crate::rcc::{Enable, Rcc};
             use super::{

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -19,7 +19,7 @@ use cast::u8;
 use embedded_time::rate::Hertz;
 
 // I²C traits
-use crate::hal::blocking::i2c::{Read, Write, WriteRead};
+use crate::hal_02::blocking::i2c::{Read, Write, WriteRead};
 
 // I/O Imports
 use crate::gpio::{AltMode, OpenDrain, Output};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@ compile_error!(
     "This crate requires one of the following features enabled: stm32l0x1, stm32l0x2, stm32l0x3"
 );
 
-use embedded_hal as hal;
+pub use embedded_hal as hal;
+pub use embedded_hal_02 as hal_02;
 
 #[cfg(feature = "stm32l0x1")]
 pub use stm32l0::stm32l0x1 as pac;

--- a/src/lptim.rs
+++ b/src/lptim.rs
@@ -1,7 +1,7 @@
 //! Low-Power Timer (LPTIM) support.
 
 use crate::gpio::{self, gpiob};
-use crate::hal;
+use crate::hal_02;
 use crate::pac::LPTIM;
 use crate::pwr::PWR;
 use crate::rcc::{Enable, Rcc, Reset};
@@ -337,7 +337,7 @@ impl<M: CountMode> LpTimer<M> {
     }
 }
 
-impl hal::timer::CountDown for LpTimer<Periodic> {
+impl hal_02::timer::CountDown for LpTimer<Periodic> {
     type Time = Hertz;
 
     fn start<T>(&mut self, freq: T)
@@ -362,9 +362,9 @@ impl hal::timer::CountDown for LpTimer<Periodic> {
     }
 }
 
-impl hal::timer::Periodic for LpTimer<Periodic> {}
+impl hal_02::timer::Periodic for LpTimer<Periodic> {}
 
-impl hal::timer::CountDown for LpTimer<OneShot> {
+impl hal_02::timer::CountDown for LpTimer<OneShot> {
     type Time = Microseconds;
 
     fn start<T>(&mut self, period: T)

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use embedded_hal::{
+pub use crate::hal_02::{
     adc::OneShot as _,
     digital::v2::*,
     prelude::*,

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -4,7 +4,7 @@ use crate::gpio::{
     gpiob::PB3,
 };
 use crate::gpio::{AltMode, PinMode};
-use crate::hal;
+use crate::hal_02;
 use crate::pac::{tim2, TIM2, TIM3};
 use crate::rcc::{Enable, Rcc, Reset};
 use cast::{u16, u32};
@@ -212,7 +212,7 @@ impl<I, C> Pwm<I, C, Unassigned> {
     }
 }
 
-impl<I, C, P> hal::PwmPin for Pwm<I, C, Assigned<P>>
+impl<I, C, P> hal_02::PwmPin for Pwm<I, C, Assigned<P>>
 where
     I: Instance,
     C: Channel,

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -30,7 +30,7 @@ use embedded_time::rate::Extensions;
 use void::Void;
 
 use crate::{
-    hal::timer::{self, Cancel as _},
+    hal_02::timer::{self, Cancel as _},
     pac,
     pwr::PWR,
     rcc::Rcc,

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,8 +6,8 @@ use core::ptr;
 use nb::block;
 
 use crate::gpio::{AltMode, PinMode};
-use crate::hal;
-use crate::hal::prelude::*;
+use crate::hal_02;
+use crate::hal_02::prelude::*;
 pub use crate::pac::{LPUART1, USART1, USART2, USART4, USART5};
 use crate::rcc::{Enable, Rcc, LSE};
 use embedded_time::rate::{Baud, Extensions};
@@ -476,7 +476,7 @@ macro_rules! usart {
                 }
             }
 
-            impl hal::serial::Read<u8> for Serial<$USARTX> {
+            impl hal_02::serial::Read<u8> for Serial<$USARTX> {
                 type Error = Error;
 
                 fn read(&mut self) -> nb::Result<u8, Error> {
@@ -484,7 +484,7 @@ macro_rules! usart {
                 }
             }
 
-             impl hal::serial::Write<u8> for  Serial<$USARTX> {
+             impl hal_02::serial::Write<u8> for  Serial<$USARTX> {
                 type Error = Error;
 
                 fn flush(&mut self) -> nb::Result<(), Self::Error> {
@@ -614,7 +614,7 @@ macro_rules! usart {
                 }
             }
 
-            impl hal::serial::Read<u8> for Rx<$USARTX> {
+            impl hal_02::serial::Read<u8> for Rx<$USARTX> {
                 type Error = Error;
 
                 fn read(&mut self) -> nb::Result<u8, Error> {
@@ -636,7 +636,7 @@ macro_rules! usart {
                 }
             }
 
-            impl hal::serial::Write<u8> for Tx<$USARTX> {
+            impl hal_02::serial::Write<u8> for Tx<$USARTX> {
                 type Error = Error;
 
                 fn flush(&mut self) -> nb::Result<(), Self::Error> {
@@ -798,7 +798,7 @@ impl Serial<LPUART1> {
 
 impl<USART> fmt::Write for Serial<USART>
 where
-    Serial<USART>: hal::serial::Write<u8>,
+    Serial<USART>: hal_02::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
@@ -811,7 +811,7 @@ where
 
 impl<USART> fmt::Write for Tx<USART>
 where
-    Tx<USART>: hal::serial::Write<u8>,
+    Tx<USART>: hal_02::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -15,7 +15,7 @@ use crate::gpio::gpioa::*;
 use crate::gpio::gpiob::*;
 
 use crate::gpio::{AltMode, Analog, OpenDrain, Output, PushPull};
-use crate::hal;
+use crate::hal_02;
 use crate::pac::SPI1;
 #[cfg(any(
     feature = "io-STM32L051",
@@ -26,7 +26,7 @@ use crate::pac::SPI1;
 use crate::pac::SPI2;
 use crate::rcc::{Enable, Rcc};
 
-pub use hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 
 /// SPI error
 #[derive(Debug)]
@@ -416,7 +416,7 @@ macro_rules! spi {
                     }
             }
 
-            impl<PINS> hal::spi::FullDuplex<u8> for Spi<$SPIX, PINS> {
+            impl<PINS> hal_02::spi::FullDuplex<u8> for Spi<$SPIX, PINS> {
                 type Error = Error;
 
                 fn read(&mut self) -> nb::Result<u8, Error> {
@@ -459,9 +459,9 @@ macro_rules! spi {
 
             }
 
-            impl<PINS> crate::hal::blocking::spi::transfer::Default<u8> for Spi<$SPIX, PINS> {}
+            impl<PINS> hal_02::blocking::spi::transfer::Default<u8> for Spi<$SPIX, PINS> {}
 
-            impl<PINS> crate::hal::blocking::spi::write::Default<u8> for Spi<$SPIX, PINS> {}
+            impl<PINS> hal_02::blocking::spi::write::Default<u8> for Spi<$SPIX, PINS> {}
         )+
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,5 +1,5 @@
 //! Timers
-use crate::hal::timer::{CountDown, Periodic};
+use crate::hal_02::timer::{CountDown, Periodic};
 use crate::pac::{tim2, tim21, tim22, tim6, TIM2, TIM21, TIM22, TIM3, TIM6};
 use crate::rcc::{Clocks, Enable, Rcc, Reset};
 use cast::{u16, u32};

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,4 +1,4 @@
-use crate::hal::watchdog;
+use crate::hal_02::watchdog;
 use crate::pac::{IWDG, WWDG};
 use crate::rcc::{Enable, Rcc};
 use embedded_time::rate::Hertz;


### PR DESCRIPTION
Followed example of how to support both 0.2.x and 1.0.0 in stm32f4xx-hal
All crate references to the existing hal use the lib export, and both the 1.0 traits and 0.2.x traits can now be supported.
Note that none of the implementation is done for the 1.0.0 traits, just organizing the existing dependencies to allow it.

I did update some dependencies here, I can roll that back if there's a desire for it.