### PR TITLE
Implement i2c::TransactionIter trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ as-slice = "0.2.1"
 cast = { version = "0.3.0", default-features = false }
 cortex-m = "0.7.0"
 cortex-m-rt = "0.7.0"
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
 embedded-time = "0.12.0"
 nb = "1.0.0"
 rtcc = { version = "0.3.0", optional = true }


### PR DESCRIPTION
This allows transactional use of the HAL and also
makes the HAL compatible with embedded-hal-compat
conversions between 0.2 and 1.0 traits.

The compat interface compatibility depends on https://github.com/ryankurte/embedded-hal-compat/pull/38