### PR TITLE
Add stm32l0x0 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ disable-linker-script = []
 
 # STM32L0 subfamilies
 # (Warning: Some peripherals, e.g. GPIO, don't follow this subfamily grouping.)
+stm32l0x0 = ["stm32l0/stm32l0x0"]
 stm32l0x1 = ["stm32l0/stm32l0x1"]
 stm32l0x2 = ["stm32l0/stm32l0x2"]
 stm32l0x3 = ["stm32l0/stm32l0x3"]
@@ -122,12 +123,12 @@ wlcsp49 = []
 #
 # Note: These are just aliases, they should not be used to directly feature gate
 # functionality in the HAL! However, user code should usually depend on a MCU alias.
-mcu-STM32L010C6Tx = ["lqfp48", "io-STM32L031", "eeprom-256", "flash-32", "ram-8"]
-mcu-STM32L010F4Px = ["tssop20", "io-STM32L021", "eeprom-128", "flash-16", "ram-2"]
-mcu-STM32L010K4Tx = ["lqfp32", "io-STM32L021", "eeprom-128", "flash-16", "ram-2"]
-mcu-STM32L010K8Tx = ["lqfp32", "io-STM32L051", "eeprom-256", "flash-64", "ram-8"]
-mcu-STM32L010R8Tx = ["lqfp64", "io-STM32L051", "eeprom-256", "flash-64", "ram-8"]
-mcu-STM32L010RBTx = ["lqfp64", "io-STM32L071", "eeprom-512", "flash-128", "ram-20"]
+mcu-STM32L010C6Tx = ["stm32l0x0", "lqfp48", "io-STM32L031", "eeprom-256", "flash-32", "ram-8"]
+mcu-STM32L010F4Px = ["stm32l0x0", "tssop20", "io-STM32L021", "eeprom-128", "flash-16", "ram-2"]
+mcu-STM32L010K4Tx = ["stm32l0x0", "lqfp32", "io-STM32L021", "eeprom-128", "flash-16", "ram-2"]
+mcu-STM32L010K8Tx = ["stm32l0x0", "lqfp32", "io-STM32L051", "eeprom-256", "flash-64", "ram-8"]
+mcu-STM32L010R8Tx = ["stm32l0x0", "lqfp64", "io-STM32L051", "eeprom-256", "flash-64", "ram-8"]
+mcu-STM32L010RBTx = ["stm32l0x0", "lqfp64", "io-STM32L071", "eeprom-512", "flash-128", "ram-20"]
 mcu-STM32L011D3Px = ["stm32l0x1", "tssop14", "io-STM32L021", "eeprom-512", "flash-8", "ram-2"]
 mcu-STM32L011D4Px = ["stm32l0x1", "tssop14", "io-STM32L021", "eeprom-512", "flash-16", "ram-2"]
 mcu-STM32L011E3Yx = ["stm32l0x1", "wlcsp25", "io-STM32L021", "eeprom-512", "flash-8", "ram-2"]

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,10 @@ fn main() {
 
     let mut feature_count = 0;
 
+    if cfg!(feature = "stm32l0x0") {
+        feature_count += 1;
+    }
+
     if cfg!(feature = "stm32l0x1") {
         feature_count += 1;
     }
@@ -23,7 +27,7 @@ fn main() {
 
     if !cfg!(feature = "disable-linker-script") {
         if feature_count != 1 {
-            panic!("\n\nMust select exactly one package for linker script generation!\nChoices: 'stm32l0x1' or 'stm32l0x2' or 'stm32l0x3'\nAlternatively, pick the mcu-feature that matches your MCU, for example 'mcu-STM32L071KBTx'\n\n");
+            panic!("\n\nMust select exactly one package for linker script generation!\nChoices: 'stm32l0x0', 'stm32l0x1' or 'stm32l0x2' or 'stm32l0x3'\nAlternatively, pick the mcu-feature that matches your MCU, for example 'mcu-STM32L071KBTx'\n\n");
         }
 
         let flash_features: Vec<u32> = [

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -37,9 +37,12 @@ use crate::pac::USART1;
 ))]
 use crate::{
     i2c,
-    pac::{I2C1, I2C2, I2C3, USART2},
+    pac::{I2C1, USART2},
     serial,
 };
+
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+use crate::pac::{I2C2, I2C3};
 
 use crate::{pac::SPI1, spi};
 

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -309,6 +309,7 @@ impl ExtiLine for GpioLine {
 /// both.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum ConfigurableLine {
+    #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
     Pvd = 16,
     RtcAlarm = 17,
     RtcTamper_CssLse = 19,
@@ -322,6 +323,7 @@ impl ExtiLine for ConfigurableLine {
         use ConfigurableLine::*;
 
         Some(match line {
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             16 => Pvd,
             17 => RtcAlarm,
             // 18 = USB (or reserved)
@@ -342,9 +344,13 @@ impl ExtiLine for ConfigurableLine {
         use ConfigurableLine::*;
 
         match self {
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             Pvd => Interrupt::PVD,
             RtcAlarm | RtcTamper_CssLse | RtcWakeup => Interrupt::RTC,
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             Comp1 | Comp2 => Interrupt::ADC_COMP,
+            #[cfg(feature = "stm32l0x0")]
+            Comp1 | Comp2 => Interrupt::ADC,
         }
     }
 }
@@ -355,10 +361,13 @@ pub enum DirectLine {
     #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
     Usb = 18,
     I2C1 = 23,
+    #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
     I2C3 = 24,
+    #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
     Usart1 = 25,
     Usart2 = 26,
     // 27 = reserved
+    #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
     Lpuart1 = 28,
     Lptim1 = 29,
 }
@@ -371,10 +380,13 @@ impl ExtiLine for DirectLine {
             #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
             18 => Usb,
             23 => I2C1,
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             24 => I2C3,
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             25 => Usart1,
             26 => Usart2,
             // 27 = reserved
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             28 => Lpuart1,
             29 => Lptim1,
             _ => return None,
@@ -393,9 +405,12 @@ impl ExtiLine for DirectLine {
             #[cfg(any(feature = "stm32l0x2", feature = "stm32l0x3"))]
             Usb => Interrupt::USB,
             I2C1 => Interrupt::I2C1,
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             I2C3 => Interrupt::I2C3,
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             Usart1 => Interrupt::USART1,
             Usart2 => Interrupt::USART2,
+            #[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
             Lpuart1 => Interrupt::AES_RNG_LPUART1,
             Lptim1 => Interrupt::LPTIM1,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,15 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
-#[cfg(not(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3")))]
+#[cfg(not(any(feature = "stm32l0x0", feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3")))]
 compile_error!(
-    "This crate requires one of the following features enabled: stm32l0x1, stm32l0x2, stm32l0x3"
+    "This crate requires one of the following features enabled: stm32l0x0, stm32l0x1, stm32l0x2, stm32l0x3"
 );
 
 use embedded_hal as hal;
 
+#[cfg(feature = "stm32l0x0")]
+pub use stm32l0::stm32l0x0 as pac;
 #[cfg(feature = "stm32l0x1")]
 pub use stm32l0::stm32l0x1 as pac;
 #[cfg(feature = "stm32l0x2")]
@@ -17,6 +19,11 @@ pub use stm32l0::stm32l0x2 as pac;
 pub use stm32l0::stm32l0x3 as pac;
 
 pub mod adc;
+#[cfg(any(
+    feature = "stm32l0x1",
+    feature = "stm32l0x2",
+    feature = "stm32l0x3",
+))]
 pub mod aes;
 pub mod calibration;
 pub mod crc;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -5,7 +5,10 @@ use crate::gpio::{
 };
 use crate::gpio::{AltMode, PinMode};
 use crate::hal;
-use crate::pac::{tim2, TIM2, TIM3};
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+use crate::pac::TIM3;
+use crate::pac::{tim2, TIM2};
+
 use crate::rcc::{Enable, Rcc, Reset};
 use cast::{u16, u32};
 use core::marker::PhantomData;
@@ -124,6 +127,10 @@ macro_rules! impl_instance {
 
 impl_instance!(
     TIM2, apb1_clk;
+);
+
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+impl_instance!(
     TIM3, apb1_clk;
 );
 

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -115,19 +115,11 @@ bus! {
     DMA1 => (AHB, dmaen, dmasmen, dmarst), // 0
     FLASH => (AHB, mifen, mifsmen, mifrst), // 8
     CRC => (AHB, crcen, crcsmen, crcrst), // 12
-    AES => (AHB, crypen, crypsmen, cryprst), // 24
 
     TIM2 => (APB1, tim2en, tim2smen, tim2rst), // 0
-    TIM6 => (APB1, tim6en, tim6smen, tim6rst), // 4
-    TIM7 => (APB1, tim7en, tim7smen, tim7rst), // 5
-    SPI2 => (APB1, spi2en, spi2smen, spi2rst), // 14
     LPUART1 => (APB1, lpuart1en, lpuart1smen, lpuart1rst), // 20
-    USART4 => (APB1, usart4en, usart4smen, usart4rst), // 19
-    USART5 => (APB1, usart5en, usart5smen, usart5rst), // 20
     I2C1 => (APB1, i2c1en, i2c1smen, i2c1rst), // 21
-    I2C2 => (APB1, i2c2en, i2c2smen, i2c2rst), // 22
     PWR => (APB1, pwren, pwrsmen, pwrrst), // 28
-    I2C3 => (APB1, i2c3en, i2c3smen, i2c3rst), // 30
     LPTIM => (APB1, lptim1en, lptim1smen, lptim1rst), // 31
 
     SYSCFG => (APB2, syscfgen, syscfgsmen, syscfgrst), // 0
@@ -135,8 +127,22 @@ bus! {
     TIM22 => (APB2, tim22en, tim22smen, tim22rst), // 5
     ADC => (APB2, adcen, adcsmen, adcrst), // 9
     SPI1 => (APB2, spi1en, spi1smen, spi1rst), // 12
-    USART1 => (APB2, usart1en, usart1smen, usart1rst), // 14
     DBG => (APB2, dbgen, dbgsmen, dbgrst), // 22
+}
+
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+bus! {
+    AES => (AHB, crypen, crypsmen, cryprst), // 24
+
+    TIM6 => (APB1, tim6en, tim6smen, tim6rst), // 4
+    TIM7 => (APB1, tim7en, tim7smen, tim7rst), // 5
+    SPI2 => (APB1, spi2en, spi2smen, spi2rst), // 14
+    USART4 => (APB1, usart4en, usart4smen, usart4rst), // 19
+    USART5 => (APB1, usart5en, usart5smen, usart5rst), // 20
+    I2C2 => (APB1, i2c2en, i2c2smen, i2c2rst), // 22
+    I2C3 => (APB1, i2c3en, i2c3smen, i2c3rst), // 30
+
+    USART1 => (APB2, usart1en, usart1smen, usart1rst), // 14
 }
 
 #[cfg(any(feature = "stm32l0x0", feature = "stm32l0x1"))]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -8,7 +8,9 @@ use nb::block;
 use crate::gpio::{AltMode, PinMode};
 use crate::hal;
 use crate::hal::prelude::*;
-pub use crate::pac::{LPUART1, USART1, USART2, USART4, USART5};
+pub use crate::pac::{LPUART1, USART2};
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+pub use crate::pac::{USART1, USART4, USART5};
 use crate::rcc::{Enable, Rcc, LSE};
 use embedded_time::rate::{Baud, Extensions};
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -173,7 +173,7 @@ pins! {
         ]
 }
 
-#[cfg(feature = "stm32l0x1")]
+#[cfg(any(feature = "stm32l0x0", feature = "stm32l0x1"))]
 pins! {
     SPI1:
         SCK: [

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,8 @@
 //! Timers
 use crate::hal::timer::{CountDown, Periodic};
-use crate::pac::{tim2, tim21, tim22, tim6, TIM2, TIM21, TIM22, TIM3, TIM6};
+use crate::pac::{tim2, tim21, tim22, TIM2, TIM21, TIM22};
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+use crate::pac::{tim6, TIM3, TIM6};
 use crate::rcc::{Clocks, Enable, Rcc, Reset};
 use cast::{u16, u32};
 use cortex_m::peripheral::syst::SystClkSource;
@@ -355,18 +357,26 @@ macro_rules! linked_timers {
 
 timers! {
     TIM2: (tim2, apb1_tim_clk, tim2::cr2::MMS_A),
-    TIM3: (tim3, apb1_tim_clk, tim2::cr2::MMS_A),
-    TIM6: (tim6, apb1_tim_clk, tim6::cr2::MMS_A),
     TIM21: (tim21, apb2_tim_clk, tim21::cr2::MMS_A),
     TIM22: (tim22, apb2_tim_clk, tim22::cr2::MMS_A),
 }
 
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+timers! {
+    TIM3: (tim3, apb1_tim_clk, tim2::cr2::MMS_A),
+    TIM6: (tim6, apb1_tim_clk, tim6::cr2::MMS_A),
+}
+
 linked_timers! {
-    // Internal trigger connection: RM0377 table 76
-    (TIM2, TIM3): (tim2_tim3, tim2::cr2::MMS_A, tim2::smcr::SMS_A, tim2::smcr::TS_A::Itr0),
     // Internal trigger connection: RM0377 table 80
     (TIM21, TIM22): (tim21_tim22, tim21::cr2::MMS_A, tim22::smcr::SMS_A, tim22::smcr::TS_A::Itr0),
 
     // Note: Other combinations would be possible as well, e.g. (TIM21, TIM2) or (TIM2, TIM22).
     // They can be implemented if needed.
+}
+
+#[cfg(any(feature = "stm32l0x1", feature = "stm32l0x2", feature = "stm32l0x3"))]
+linked_timers! {
+    // Internal trigger connection: RM0377 table 76
+    (TIM2, TIM3): (tim2_tim3, tim2::cr2::MMS_A, tim2::smcr::SMS_A, tim2::smcr::TS_A::Itr0),
 }


### PR DESCRIPTION
I forked and modified this project for working on a board based on the STM32L010C6T6. I've been using this code for a while now so I feel like it might be time to contribute back.

I think the code might need some adjustment but I don't know enough about this HAL to really judge.

Closes: https://github.com/stm32-rs/stm32l0xx-hal/issues/141